### PR TITLE
fix: Add missing import alias for private function

### DIFF
--- a/src/anaconda_cloud_auth/actions.py
+++ b/src/anaconda_cloud_auth/actions.py
@@ -1,4 +1,5 @@
 from anaconda_auth.actions import *  # noqa: F403
+from anaconda_auth.actions import _do_auth_flow  # noqa: F401
 from anaconda_cloud_auth import warn  # noqa: F401
 
 warn()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -8,6 +8,7 @@ PUBLIC_IMPORTS = [
     "login",
     "logout",
     "client_factory",
+    "actions._do_auth_flow",
     "actions.get_api_key",
     "actions.is_logged_in",
     "actions.login",


### PR DESCRIPTION
Adds an import alias for `anaconda_cloud_auth._do_auth_flow`, which is imported by at least `anaconda-cloud-curl`. Will follow up further with a more complete solution that doesn't rely on `import *`, since that doesn't import private functions.