### PR TITLE
fix: Catch IndexError instead of KeyError

### DIFF
--- a/src/anaconda_auth/_conda/auth_handler.py
+++ b/src/anaconda_auth/_conda/auth_handler.py
@@ -67,7 +67,7 @@ class AnacondaAuthHandler(ChannelAuthBase):
         # Return the first one, assuming this is not an org-specific channel
         try:
             return token_info.repo_tokens[0].token
-        except KeyError:
+        except IndexError:
             pass
 
         return None


### PR DESCRIPTION
An `IndexError` is raised if no repo tokens are installed but the auth handler plugin is configured.