### PR TITLE
fix: GitHub Actions job to upload to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           ./dist/*.whl
 
   publish-to-pypi:
-    name: Build & publish to PyPI
+    name: Publish to PyPI
     # Only publish to PyPI if a tagged release
     if: startsWith(github.event.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
@@ -97,7 +97,7 @@ jobs:
     - name: Install build dependencies
       run: pip install twine
     - name: Upload to PyPI with twine
-      run: python -m twine upload ~/dist/*
+      run: python -m twine upload ./dist/*
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
* Fixes the path to the wheel files to upload to PyPI
* Updates the job name to "Publish" instead if "Build & publish", since build happens in an earlier job