### PR TITLE
fix: Add a runtime constraint to ensure update of conda-token

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -32,6 +32,7 @@ outputs:
         {% endfor %}
       run_constrained:
         - {{ pin_subpackage("anaconda-cloud-auth", exact=True) }}
+        - conda-token >=0.6.0
     test:
       imports:
         - anaconda_auth


### PR DESCRIPTION
Adds a new runtime constraint to ensure we force an upgrade to `conda-token>=0.6.0` when it is installed already when `anaconda-auth` is installed.