### PR TITLE
feat: Update terminal message during token installation to remove token

### DIFF
--- a/src/anaconda_auth/repo.py
+++ b/src/anaconda_auth/repo.py
@@ -106,7 +106,7 @@ class RepoAPIClient(BaseClient):
         response = self._create_repo_token(org_name=org_name)
 
         console.print(
-            f"Your conda token is: [cyan]{response.token}[/cyan], which expires [cyan]{response.expires_at}[/cyan]"
+            f"Your conda has been installed and expires [cyan]{response.expires_at}[/cyan]. To view your token(s), you can use [cyan]anaconda token list[/cyan]"
         )
         return response.token
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -413,3 +413,22 @@ def test_get_business_organizations_for_user_only_starter(
     client = RepoAPIClient()
     organizations = client.get_business_organizations_for_user()
     assert organizations == []
+
+
+def test_issue_new_token_prints_success_message(
+    org_name: str,
+    mocker: MockerFixture,
+    capsys: pytest.CaptureFixture
+) -> None:
+    client = RepoAPIClient()
+    mocker.patch.object(client, "_get_repo_token_info", return_value=None)
+
+    mock_response = mocker.MagicMock()
+    mock_response.expires_at = "2025-12-31"
+    mocker.patch.object(client, "_create_repo_token", return_value=mock_response)
+    client.issue_new_token(org_name=org_name)
+    res = capsys.readouterr()
+    expected_msg = "Your conda has been installed and expires 2025-12-31. To view your token(s), you can use anaconda token list\n"
+
+    assert expected_msg in res.out
+


### PR DESCRIPTION
JIRA: https://anaconda.atlassian.net/browse/HUB-1556

Description:
- Changed the message during the token install to not include the issued token.

How to Test:
- Added a unit test that would mock the issued new token function and check the success message matches the expected message