### PR TITLE
fix: Don't require login just to list installed tokens

### DIFF
--- a/src/anaconda_auth/repo.py
+++ b/src/anaconda_auth/repo.py
@@ -190,7 +190,7 @@ def list_tokens() -> None:
 
     tokens = token_list()
 
-    token_info = TokenInfo.load()
+    token_info = TokenInfo.load(create=True)
     repo_tokens = token_info.repo_tokens
 
     if not (tokens or repo_tokens):

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -43,9 +43,16 @@ def valid_api_key():
     return token_info
 
 
-@pytest.fixture()
-def no_tokens_installed(mocker: MockerFixture, valid_api_key: TokenInfo) -> None:
-    valid_api_key.delete()
+@pytest.fixture(params=[True, False])
+def no_tokens_installed(
+    request, mocker: MockerFixture, valid_api_key: TokenInfo
+) -> None:
+    if request.param:
+        # Remove the API key
+        valid_api_key.delete()
+    else:
+        # Models the situation where we have a valid API key but it has no attached repo tokens.
+        pass
 
     # No legacy tokens either
     mocker.patch(

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -31,8 +31,8 @@ def business_org_id() -> UUID:
     return uuid4()
 
 
-@pytest.fixture(autouse=True)
-def token_info():
+@pytest.fixture()
+def valid_api_key():
     token_info = TokenInfo.load(create=True)
     # The important part is that the key is not expired. If this still exists in
     # 2099, Trump hasn't blown up the world and it has far exceeded my expectations.
@@ -44,8 +44,8 @@ def token_info():
 
 
 @pytest.fixture()
-def no_tokens_installed(mocker: MockerFixture, token_info: TokenInfo) -> None:
-    token_info.delete()
+def no_tokens_installed(mocker: MockerFixture, valid_api_key: TokenInfo) -> None:
+    valid_api_key.delete()
 
     # No legacy tokens either
     mocker.patch(
@@ -55,10 +55,10 @@ def no_tokens_installed(mocker: MockerFixture, token_info: TokenInfo) -> None:
 
 
 @pytest.fixture()
-def token_is_installed(org_name: str, token_info: TokenInfo) -> TokenInfo:
-    token_info.set_repo_token(org_name=org_name, token="test-token")
-    token_info.save()
-    return token_info
+def token_is_installed(org_name: str, valid_api_key: TokenInfo) -> TokenInfo:
+    valid_api_key.set_repo_token(org_name=org_name, token="test-token")
+    valid_api_key.save()
+    return valid_api_key
 
 
 @pytest.fixture(autouse=True)
@@ -286,6 +286,7 @@ def test_token_install_exists_already_accept(
 def test_token_install_exists_already_decline(
     option_flag: str,
     org_name: str,
+    valid_api_key: TokenInfo,
     token_exists_in_service: None,
     token_created_in_service: str,
     *,

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -44,6 +44,17 @@ def token_info():
 
 
 @pytest.fixture()
+def no_tokens_installed(mocker: MockerFixture, token_info: TokenInfo) -> None:
+    token_info.delete()
+
+    # No legacy tokens either
+    mocker.patch(
+        "anaconda_auth._conda.repo_config.read_binstar_tokens",
+        return_value={},
+    )
+
+
+@pytest.fixture()
 def token_is_installed(org_name: str, token_info: TokenInfo) -> TokenInfo:
     token_info.set_repo_token(org_name=org_name, token="test-token")
     token_info.save()
@@ -206,14 +217,10 @@ def repodata_json_available_with_token(
     )
 
 
-def test_token_list_no_tokens(mocker: MockerFixture, invoke_cli: CLIInvoker) -> None:
-    mock = mocker.patch(
-        "anaconda_auth._conda.repo_config.read_binstar_tokens",
-        return_value={},
-    )
+def test_token_list_no_tokens(
+    invoke_cli: CLIInvoker, no_tokens_installed: None
+) -> None:
     result = invoke_cli(["token", "list"])
-
-    mock.assert_called_once()
 
     assert result.exit_code == 1
     assert (


### PR DESCRIPTION
We don't want the `anaconda token list` command to require login. The edge case here is if the user does not yet have an API key from `anaconda login`. When we load the `TokenInfo` object from keyring, we need to ensure we don't raise an exception if no object is found.

The result in that case is that no repo tokens will be found and the expected message will be displayed in the terminal:

<img width="493" alt="image" src="https://github.com/user-attachments/assets/088dfbc5-88e6-470e-9c30-9d162b6cb26e" />
