### PR TITLE
fix(ci): Use ubuntu-latest image for pre-commit job

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -27,7 +27,7 @@ jobs:
   pre-commit:
     runs-on:
       labels:
-        - self-hosted-default
+        - self-hosted-amd64-medium-privileged-on-demand
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -27,7 +27,7 @@ jobs:
   pre-commit:
     runs-on:
       labels:
-        - self-hosted-amd64-medium-privileged-on-demand
+        - ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
There is no longer a `self-hosted-default` image name since the repo is public.