### PR TITLE
fix: Add additional import alias to address Navigator bug

### DIFF
--- a/src/anaconda_cloud_auth/client.py
+++ b/src/anaconda_cloud_auth/client.py
@@ -1,4 +1,7 @@
 from anaconda_auth.client import *  # noqa: F403
 from anaconda_cloud_auth import warn  # noqa: F401
 
+# The following import addresses a bug in Navigator, which imported from the wrong module by mistake
+from anaconda_cloud_auth.config import AnacondaCloudConfig  # noqa: F401
+
 warn()

--- a/src/anaconda_cloud_auth/client.py
+++ b/src/anaconda_cloud_auth/client.py
@@ -1,7 +1,10 @@
 from anaconda_auth.client import *  # noqa: F403
-from anaconda_cloud_auth import warn  # noqa: F401
 
-# The following import addresses a bug in Navigator, which imported from the wrong module by mistake
-from anaconda_cloud_auth.config import AnacondaCloudConfig  # noqa: F401
+# The following imports address a bug in Navigator, which imported from the wrong module by mistake
+from anaconda_auth.config import AnacondaCloudConfig  # noqa: F401
+from anaconda_auth.token import TokenInfo  # noqa: F401
+
+# This one needs to stay to raise the deprecation warning
+from anaconda_cloud_auth import warn  # noqa: F401
 
 warn()


### PR DESCRIPTION
The following error is being seen in Navigator tests:

```
FAILED tests/current/api/cloud/test_api.py::test_init - AttributeError: module 'anaconda_cloud_auth.client' has no attribute 'AnacondaCloudConfig'. Did you mean: 'AnacondaAuthConfig'?
```

This import should be from the `anaconda_cloud_auth.config` module instead of `client`. However, to maintain compatibility with existing releases, we add that import alias in this PR.