### PR TITLE
fix: Reconcile domain config inconsistencies to resolve error in Assistant plugin

### DIFF
--- a/src/anaconda_auth/actions.py
+++ b/src/anaconda_auth/actions.py
@@ -219,8 +219,24 @@ def logout(config: Optional[AnacondaAuthConfig] = None) -> None:
     """Log out of anaconda.com."""
     if config is None:
         config = AnacondaAuthConfig()
+
     try:
         token_info = TokenInfo.load(domain=config.domain)
+        token_info.delete()
+    except TokenNotFoundError:
+        pass
+
+    if config.domain != "anaconda.com":
+        # Since anaconda.com is the default, don't do anything special if
+        # User explicitly overrode the configured domain.
+        return
+
+    # If the request was for anaconda.com (the default), also remove
+    # anaconda.cloud if it exists. This is just an edge case for the
+    # likely rare scenario where a user has a stored token for both
+    # domains.
+    try:
+        token_info = TokenInfo.load(domain="anaconda.cloud")
         token_info.delete()
     except TokenNotFoundError:
         pass

--- a/src/anaconda_auth/config.py
+++ b/src/anaconda_auth/config.py
@@ -126,7 +126,6 @@ class AnacondaCloudConfig(AnacondaAuthConfig, plugin_name="cloud"):
         extra="ignore",
         ignored_types=(cached_property,),
     )
-    domain: str = "anaconda.cloud"
     oidc_request_headers: Dict[str, str] = _OLD_OIDC_REQUEST_HEADERS
 
     def __init__(self, raise_deprecation_warning: bool = True, **kwargs: Any):

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -303,3 +303,26 @@ def test_token_reload_after_migration_via_anaconda_cloud_config(
     config = AnacondaCloudConfig()
     loaded_token = TokenInfo.load(domain=config.domain)
     assert loaded_token.api_key == "TEST_KEY"
+
+
+@pytest.mark.parametrize(
+    "saved_domains",
+    [
+        ["anaconda.cloud"],
+        ["anaconda.com"],
+        ["anaconda.cloud", "anaconda.com"],
+    ],
+)
+def test_logout_removes_anaconda_cloud_tokens(saved_domains: str) -> None:
+    # Given: The token is saved in keyring in either domain, or both
+    for saved_domain in saved_domains:
+        original_token = TokenInfo(api_key="TEST_KEY", domain=saved_domain)
+        original_token.save()
+
+    # When: I logout
+    logout()
+
+    # Then: neither of the domains contain a token
+    for domain in ["anaconda.com", "anaconda.cloud"]:
+        with pytest.raises(TokenNotFoundError):
+            TokenInfo.load(domain)


### PR DESCRIPTION
## Summary

### The bug

With the release of `anaconda-cloud-auth=0.8.2` we identified an incompatibility when e.g. the following occurs:

```python
from anaconda_cloud_auth import login
from anaconda_cloud_auth.config import AnacondaCloudConfig

login()  # Now defaults to using auth.anaconda.com and storing token with domain "anaconda.com"

config = AnacondaCloudAuth()  # Has a default domain of "anaconda.cloud"
token_info = TokenInfo.load(domain=config.domain)  # There is no token with domain "anaconda.cloud" since login assumed "anaconda.com" by default
```

### The fix

Since I had not anticipated the explicit instantiations of an `AnacondaCloudConfig` object in one place but not the other, we need to ensure that all instantiations have a consistent default `domain` field. To do this, we can just remove the attribute from the class and let it inherit the value from the `AnacondaAuthConfig`.

## Impact

The result of this change will be the following:

* All usages of `anaconda-cloud-auth >=0.8.4` will default to using auth.anaconda.com for authentication and token storage
* This will allow all existing clients to work consistently and get users upgraded to the new domain
* Individual projects can pin down if concerned, while working to update from `anaconda-cloud-auth` -> `anaconda-auth`
* We will request a repodata hotfix to prevent installing `anaconda-cloud-auth=0.8.2` alongside affected versions of the Assistant and other clients

