### PR TITLE
feat: Update login success and error URLs to point to anaconda.com

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -2,7 +2,7 @@
 LOGGING_LEVEL="INFO"
 
 # Base URL for all API endpoints
-ANACONDA_AUTH_DOMAIN="anaconda.cloud"
+ANACONDA_AUTH_DOMAIN="anaconda.com"
 
 # Authentication settings
 ANACONDA_AUTH_CLIENT_ID="b4ad7f1d-c784-46b5-a9fe-106e50441f5a"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The following parameters in the `plugin.auth` section control the login actions 
 
 | Parameter | Env variable | Description | Default value |
 |-|-|-|-|
-| `domain` | `ANACONDA_AUTH_DOMAIN` | Authentication and API request domain | `"anaconda.cloud"` |
+| `domain` | `ANACONDA_AUTH_DOMAIN` | Authentication and API request domain | `"anaconda.com"` |
 | `ssl_verify` | `ANACONDA_AUTH_SSL_VERIFY` | SSL verification for all requests | `True` |
 | `preferred_token_storage` | `ANACONDA_AUTH_PREFERRED_TOKEN_STORAGE` | Where to store the login token; can be `"anaconda-keyring"` or `"system"` | `"anaconda-keyring"` |
 | `api_key` | `ANACONDA_AUTH_API_KEY` | API key; if `None`, defaults to keyring storage | `None` |
@@ -147,7 +147,7 @@ print(response.json())
 
 BaseClient accepts the following optional arguments.
 
-* `domain`: Domain to use for requests, defaults to `anaconda.cloud`
+* `domain`: Domain to use for requests, defaults to `anaconda.com`
 * `ssl_verify`: Enable SSL verification, defaults to `True`
 * `api_key`: API key to use for requests, if unspecified, uses token set by `anaconda login`
 * `user_agent`: Defaults to `anaconda-auth/<package-version>`
@@ -198,7 +198,7 @@ AuthenticationMissingError: Login is required to complete this action.
 Continue with interactive login? [y/n]: n
 
 To configure your credentials you can run
-  anaconda login --at cloud
+  anaconda login --at anaconda.com
 
 or set your API key using the ANACONDA_AUTH_API_KEY env var
 
@@ -233,7 +233,7 @@ For this example subcommand, the user may provide incorrect inputs that are pass
 
 ```text
 > anaconda plugin do-something 'input-data'
-HTTPError: 422 Client Error: Unprocessable Entity for url: https://anaconda.cloud/api/something
+HTTPError: 422 Client Error: Unprocessable Entity for url: https://anaconda.com/api/something
 
 To see a more detailed error message run the command again as
   anaconda --verbose plugin do-something

--- a/src/anaconda_auth/_conda/plugins.py
+++ b/src/anaconda_auth/_conda/plugins.py
@@ -22,7 +22,7 @@ def conda_auth_handlers() -> Iterable[plugins.CondaAuthHandler]:
 
     ```yaml
     channel_settings:
-      - channel: https://repo.anaconda.cloud/repo/main
+      - channel: https://repo.anaconda.cloud/*
         auth: anaconda-auth
     ```
 

--- a/src/anaconda_auth/actions.py
+++ b/src/anaconda_auth/actions.py
@@ -104,17 +104,15 @@ def request_access_token(
 
 def _do_auth_flow(config: Optional[AnacondaAuthConfig] = None) -> str:
     """Do the browser-based auth flow and return the short-lived access_token and id_token tuple."""
-    if config is None:
-        config = AnacondaAuthConfig()
+    config = config or AnacondaAuthConfig()
 
-    redirect_uri = config.redirect_uri
     state = str(uuid.uuid4())
     code_verifier, code_challenge = pkce.generate_pkce_pair(code_verifier_length=128)
 
     _send_auth_code_request(code_challenge, state, config)
 
     # Listen for the response
-    auth_code = capture_auth_code(redirect_uri, state)
+    auth_code = capture_auth_code(config.redirect_uri, state=state, config=config)
     logger.debug("Authentication successful! Getting JWT token.")
 
     # Do auth code exchange

--- a/src/anaconda_auth/cli.py
+++ b/src/anaconda_auth/cli.py
@@ -32,7 +32,7 @@ def _continue_with_login() -> int:
             console.print(
                 dedent("""
                 To configure your credentials you can run
-                  [green]anaconda login --at cloud[/green]
+                  [green]anaconda login --at anaconda.com[/green]
 
                 or set your API key using the [green]ANACONDA_AUTH_API_KEY[/green] env var
 

--- a/src/anaconda_auth/config.py
+++ b/src/anaconda_auth/config.py
@@ -15,8 +15,8 @@ from anaconda_auth import __version__ as version
 from anaconda_cli_base.config import AnacondaBaseSettings
 from anaconda_cli_base.console import console
 
-LOGIN_SUCCESS_URL = "https://anaconda.cloud/local-login-success"
-LOGIN_ERROR_URL = "https://anaconda.cloud/local-login-error"
+LOGIN_SUCCESS_URL = "https://anaconda.com/app/local-login-success"
+LOGIN_ERROR_URL = "https://anaconda.com/app/local-login-error"
 
 
 def _raise_deprecated_field_set_warning(set_fields: Dict[str, Any]) -> None:

--- a/src/anaconda_auth/config.py
+++ b/src/anaconda_auth/config.py
@@ -15,9 +15,6 @@ from anaconda_auth import __version__ as version
 from anaconda_cli_base.config import AnacondaBaseSettings
 from anaconda_cli_base.console import console
 
-LOGIN_SUCCESS_URL = "https://anaconda.com/app/local-login-success"
-LOGIN_ERROR_URL = "https://anaconda.com/app/local-login-error"
-
 
 def _raise_deprecated_field_set_warning(set_fields: Dict[str, Any]) -> None:
     fields_str = ", ".join(sorted(f'"{s}"' for s in set_fields.keys()))
@@ -47,6 +44,8 @@ class AnacondaAuthConfig(AnacondaBaseSettings, plugin_name="auth"):
     redirect_uri: str = "http://127.0.0.1:8000/auth/oidc"
     openid_config_path: str = "/.well-known/openid-configuration"
     oidc_request_headers: Dict[str, str] = {"User-Agent": f"anaconda-auth/{version}"}
+    login_success_path: str = "/app/local-login-success"
+    login_error_path: str = "/app/local-login-error"
 
     def __init__(self, **kwargs: Any):
         if self.__class__ == AnacondaAuthConfig:
@@ -74,6 +73,16 @@ class AnacondaAuthConfig(AnacondaBaseSettings, plugin_name="auth"):
     def well_known_url(self) -> str:
         """The URL from which to load the OpenID configuration."""
         return urljoin(f"https://{self.auth_domain}", self.openid_config_path)
+
+    @property
+    def login_success_url(self) -> str:
+        """The location to redirect after auth flow, if successful."""
+        return urljoin(f"https://{self.domain}", self.login_success_path)
+
+    @property
+    def login_error_url(self) -> str:
+        """The location to redirect after auth flow, if there is an error."""
+        return urljoin(f"https://{self.domain}", self.login_error_path)
 
     @property
     def oidc(self) -> "OpenIDConfiguration":

--- a/src/anaconda_auth/handlers.py
+++ b/src/anaconda_auth/handlers.py
@@ -48,7 +48,6 @@ class AuthCodeRedirectServer(HTTPServer):
         self.result: Union[Result, None] = None
         self.host_name = str(self.server_address[0])
         self.oidc_path = oidc_path
-        print(f"{self.host_name=}, {self.oidc_path=}")
         self.config = config or AnacondaAuthConfig()
 
     def __enter__(self) -> "AuthCodeRedirectServer":

--- a/src/anaconda_auth/handlers.py
+++ b/src/anaconda_auth/handlers.py
@@ -70,7 +70,7 @@ class AuthCodeRedirectServer(HTTPServer):
             server=self,
             oidc_path=self.oidc_path,
             host_name=self.host_name,
-            login_succes_url=self.config.login_success_url,
+            login_success_url=self.config.login_success_url,
             login_error_url=self.config.login_error_url,
         )
 

--- a/src/anaconda_auth/handlers.py
+++ b/src/anaconda_auth/handlers.py
@@ -48,6 +48,7 @@ class AuthCodeRedirectServer(HTTPServer):
         self.result: Union[Result, None] = None
         self.host_name = str(self.server_address[0])
         self.oidc_path = oidc_path
+        print(f"{self.host_name=}, {self.oidc_path=}")
         self.config = config or AnacondaAuthConfig()
 
     def __enter__(self) -> "AuthCodeRedirectServer":
@@ -65,13 +66,13 @@ class AuthCodeRedirectServer(HTTPServer):
     def finish_request(self, request: TRequest, client_address: str) -> None:
         """Finish one request by instantiating RequestHandlerClass."""
         AuthCodeRedirectRequestHandler(
-            self.oidc_path,
-            self.host_name,
-            self.config.login_success_url,
-            self.config.login_error_url,
             request,
             client_address,
             server=self,
+            oidc_path=self.oidc_path,
+            host_name=self.host_name,
+            login_succes_url=self.config.login_success_url,
+            login_error_url=self.config.login_error_url,
         )
 
 
@@ -82,11 +83,11 @@ class AuthCodeRedirectRequestHandler(BaseHTTPRequestHandler):
 
     def __init__(
         self,
+        *args: Any,
         oidc_path: str,
         host_name: str,
         login_success_url: str,
         login_error_url: str,
-        *args: Any,
         **kwargs: Any,
     ):
         # these are set before __init__ because __init__ calls the do_GET method

--- a/src/anaconda_auth/handlers.py
+++ b/src/anaconda_auth/handlers.py
@@ -44,7 +44,7 @@ class AuthCodeRedirectServer(HTTPServer):
         server_address: Tuple[str, int],
         config: Optional[AnacondaAuthConfig] = None,
     ):
-        super().__init__(server_address, AuthCodeRedirectRequestHandler)
+        super().__init__(server_address, AuthCodeRedirectRequestHandler)  # type: ignore[arg-type]
         self.result: Union[Result, None] = None
         self.host_name = str(self.server_address[0])
         self.oidc_path = oidc_path

--- a/src/anaconda_auth/handlers.py
+++ b/src/anaconda_auth/handlers.py
@@ -131,7 +131,10 @@ class AuthCodeRedirectRequestHandler(BaseHTTPRequestHandler):
             self._handle_auth(query_params)
 
 
-def capture_auth_code(redirect_uri: str, state: str) -> str:
+def capture_auth_code(
+    redirect_uri: str, state: str, config: Optional[AnacondaAuthConfig] = None
+) -> str:
+    config = config or AnacondaAuthConfig()
     parsed_url = urlparse(redirect_uri)
 
     host_name, port = parsed_url.netloc.split(":")
@@ -140,7 +143,9 @@ def capture_auth_code(redirect_uri: str, state: str) -> str:
 
     logger.debug(f"Listening on: {redirect_uri}")
 
-    with AuthCodeRedirectServer(oidc_path, (host_name, server_port)) as web_server:
+    with AuthCodeRedirectServer(
+        oidc_path, (host_name, server_port), config=config
+    ) as web_server:
         web_server.handle_request()
 
     result = web_server.result

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -43,7 +43,7 @@ def test_server_response_success(server: AuthCodeRedirectServer) -> None:
     assert server.result.state == "some-state"
 
     assert response.status_code == 200
-    assert response.url == "https://anaconda.cloud/local-login-success"
+    assert response.url == "https://anaconda.com/app/local-login-success"
 
 
 @pytest.mark.parametrize(
@@ -61,7 +61,7 @@ def test_server_response_error(
         f"http://localhost:{SERVER_PORT}/auth/oidc?state=some-state?{query_params}"
     )
     assert response.status_code == 200
-    assert response.url == "https://anaconda.cloud/local-login-error"
+    assert response.url == "https://anaconda.com/app/local-login-error"
 
 
 def test_server_response_not_found(server: AuthCodeRedirectServer) -> None:


### PR DESCRIPTION
Updates the final URL references from anaconda.cloud to anaconda.com. These are the URLs which the browser is redirected to after attempting the auth code exchange locally.

In addition to updating the URLs, we refactor them such that the paths are stored as configuration variables, rather than as module-level constants.