### PR TITLE
fix: Suppress `CondaKeyError` during conda configuration

### DIFF
--- a/src/anaconda_auth/_conda/repo_config.py
+++ b/src/anaconda_auth/_conda/repo_config.py
@@ -316,10 +316,8 @@ def _get_from_condarc(
 
     # Capture the JSON output from stdout
     string_io = io.StringIO()
-    err_io = io.StringIO()
     with contextlib.redirect_stdout(string_io):
-        with contextlib.redirect_stderr(err_io):
-            run_command(Commands.CONFIG, *config_args)
+        run_command(Commands.CONFIG, *config_args)
 
     try:
         result = json.loads(string_io.getvalue())

--- a/src/anaconda_auth/repo.py
+++ b/src/anaconda_auth/repo.py
@@ -106,7 +106,7 @@ class RepoAPIClient(BaseClient):
         response = self._create_repo_token(org_name=org_name)
 
         console.print(
-            f"Your conda has been installed and expires [cyan]{response.expires_at}[/cyan]. To view your token(s), you can use [cyan]anaconda token list[/cyan]"
+            f"Your conda token has been installed and expires [cyan]{response.expires_at}[/cyan]. To view your token(s), you can use [cyan]anaconda token list[/cyan]"
         )
         return response.token
 

--- a/tests/conda_token/test_condarc.py
+++ b/tests/conda_token/test_condarc.py
@@ -47,6 +47,15 @@ def test_default_channels():
         assert _read_test_condarc(rc) == final_condarc
 
 
+def test_default_channels_no_exception(capsys):
+    """Ensure that no CondaKeyError is raised if the .condarc does not have default_channels defined."""
+    with make_temp_condarc() as rc:
+        configure_default_channels(condarc_file=rc, force=True)
+
+    res = capsys.readouterr()
+    assert "CondaKeyError: 'default_channels'" not in res.err
+
+
 def test_replace_default_channels():
     original_condarc = dedent(
         """\

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -441,7 +441,7 @@ def test_issue_new_token_prints_success_message_via_client(
     mocker.patch.object(client, "_create_repo_token", return_value=mock_response)
     client.issue_new_token(org_name=org_name)
     res = capsys.readouterr()
-    expected_msg = "Your conda has been installed and expires 2025-12-31 00:00:00. To view your token(s), you can use anaconda token list\n"
+    expected_msg = "Your conda token has been installed and expires 2025-12-31 00:00:00. To view your token(s), you can use anaconda token list\n"
 
     assert expected_msg in res.out
 
@@ -456,6 +456,6 @@ def test_issue_new_token_prints_success_message_via_cli(
 ) -> None:
     result = invoke_cli(["token", "install", "--org", org_name], input="y\nn\n")
 
-    expected_msg = "Your conda has been installed and expires 2025-01-01 00:00:00. To view your token(s), you can use anaconda token list\n"
+    expected_msg = "Your conda token has been installed and expires 2025-01-01 00:00:00. To view your token(s), you can use anaconda token list\n"
     assert result.exit_code == 0, result.stdout
     assert expected_msg in result.stdout


### PR DESCRIPTION
## Summary

If the `default_channels` key doesn't exist in the `.condarc` file, conda will raise and log a `CondaKeyError` to stderr. We do not want to show this, since we are essentially just making sure the field is cleared out before writing it back in.

This PR suppresses that statement (only if it's a `CondaKeyError`), only during the one invocation.