### PR TITLE
[chore] repo token generation support api keys

### DIFF
--- a/src/anaconda_auth/repo.py
+++ b/src/anaconda_auth/repo.py
@@ -40,19 +40,6 @@ class SubscriptionData(BaseModel):
 
 
 class RepoAPIClient(BaseClient):
-    def __init__(self) -> None:
-        super().__init__()
-        self._access_token: str | None = None
-
-    def _ensure_access_token(self) -> None:
-        """Some endpoints do not accept API keys, so this method ensures we perform
-        an interactive authentication and then cache the access token.
-        """
-        if self._access_token is not None:
-            return
-        self._access_token = _do_auth_flow()
-        self.auth.api_key = self._access_token  # type: ignore
-
     def _get_repo_token_info(self, org_name: str) -> TokenInfoResponse | None:
         """Return the token information, if it exists.
 
@@ -63,7 +50,6 @@ class RepoAPIClient(BaseClient):
             The token information, including its id and expiration date, or
             None if a token doesn't exist.
         """
-        self._ensure_access_token()
         response = self.get(
             f"/api/organizations/{org_name}/ce/current-token",
         )
@@ -81,7 +67,6 @@ class RepoAPIClient(BaseClient):
         Returns:
             The token information, including its value and expiration date.
         """
-        self._ensure_access_token()
         response = self.put(
             f"/api/organizations/{org_name}/ce/current-token",
             json={"confirm": "yes"},


### PR DESCRIPTION
On the platform the repo token endpoint now accepts API keys, we need not ask the user to login a second time.