### PR TITLE
feat: Add conda subcommand definition for conda-token

### DIFF
--- a/src/anaconda_auth/_conda/plugins.py
+++ b/src/anaconda_auth/_conda/plugins.py
@@ -6,6 +6,7 @@ conditionally import it in case conda is not installed in the user's environment
 """
 
 from typing import Iterable
+from typing import Optional
 
 from conda import plugins
 
@@ -15,18 +16,18 @@ from anaconda_auth._conda.conda_token import cli
 __all__ = ["conda_subcommands", "conda_auth_handlers"]
 
 
-def _cli_wrapper(argv: list[str] | None = None) -> int:
+def _cli_wrapper(argv: Optional[list[str]] = None) -> int:  # type: ignore
     # If argv is empty tuple, we need to set it back to None
     return cli(argv=argv or None)
 
 
 @plugins.hookimpl
-def conda_subcommands():
+def conda_subcommands() -> Iterable[plugins.CondaSubcommand]:
     """Defines subcommands into conda itself (not `anaconda` CLI)."""
     yield plugins.CondaSubcommand(
         name="token",
         summary="Set repository access token and configure default_channels",
-        action=_cli_wrapper,
+        action=_cli_wrapper,  # type: ignore
     )
 
 

--- a/src/anaconda_auth/_conda/plugins.py
+++ b/src/anaconda_auth/_conda/plugins.py
@@ -10,8 +10,24 @@ from typing import Iterable
 from conda import plugins
 
 from anaconda_auth._conda.auth_handler import AnacondaAuthHandler
+from anaconda_auth._conda.conda_token import cli
 
-__all__ = ["conda_auth_handlers"]
+__all__ = ["conda_subcommands", "conda_auth_handlers"]
+
+
+def _cli_wrapper(argv: list[str] | None = None) -> int:
+    # If argv is empty tuple, we need to set it back to None
+    return cli(argv=argv or None)
+
+
+@plugins.hookimpl
+def conda_subcommands():
+    """Defines subcommands into conda itself (not `anaconda` CLI)."""
+    yield plugins.CondaSubcommand(
+        name="token",
+        summary="Set repository access token and configure default_channels",
+        action=_cli_wrapper,
+    )
 
 
 @plugins.hookimpl

--- a/tests/conda_token/test_cli.py
+++ b/tests/conda_token/test_cli.py
@@ -1,10 +1,18 @@
 import pytest
 import urllib3.exceptions
+from conda.cli.main import main as run_command
 from packaging.version import parse
 
 from anaconda_auth._conda.conda_token import cli
 from anaconda_auth._conda.repo_config import CONDA_VERSION
 from anaconda_auth._conda.repo_config import CondaVersionWarning
+
+
+def test_conda_subcommand_plugin(mocker):
+    """Check that we access the CLI via the plugin system."""
+    mock = mocker.patch("anaconda_auth._conda.plugins._cli_wrapper")
+    run_command("token", "set", "MY-TOKEN")
+    mock.assert_called_with(("set", "MY-TOKEN"))
 
 
 @pytest.mark.skip(reason="blocking release in CI but passing fine locally")


### PR DESCRIPTION
## Summary

[CLI-6](https://anaconda.atlassian.net/browse/CLI-6)

In order to complete migration of `conda-token` into `anaconda-auth` for a long-term controlled deprecation, we must move the `conda token` definition. This PR adds a proper conda subcommand definition, delegating to the legacy CLI implementation which was migrated over in #12.

With this, both `conda-token` entrypoint and `conda token` subcommand entrypoint will be executed by the `cli()` function inside `anaconda_auth._conda.conda_token`.

Separately, recipe updates will be made to enforce that non-incompatible versions of `anaconda-auth` and `conda-token` cannot be installed into the same environment simultaneously.

This PR stacks on top of #137 

[CLI-6]: https://anaconda.atlassian.net/browse/CLI-6?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ