### PR TITLE
fix: Replace references to removed `python_api` module in conda

### DIFF
--- a/src/anaconda_auth/_conda/conda_api.py
+++ b/src/anaconda_auth/_conda/conda_api.py
@@ -21,7 +21,7 @@ class Commands:
     SEARCH = "search"
 
 
-def run_command(*args, use_exception_handler=False):
+def run_command(*args, use_exception_handler=False):  # type: ignore
     args = ("python", "-m", "conda") + args
     proc = subprocess.run(args, capture_output=True, text=True)
     return proc.stdout, proc.stderr, proc.returncode

--- a/src/anaconda_auth/_conda/conda_api.py
+++ b/src/anaconda_auth/_conda/conda_api.py
@@ -1,0 +1,27 @@
+# This is a minimal reimplementation of the deprecated conda.cli.python_api
+# module. It uses the subprocess module to duplicate the fullest extent of
+# the run_command functionality needed for tests. But most of the internal
+# uses of run_command do not require this overhead and are better served
+# working in process. So when subprocess is needed, we do this:
+#   from conda_token.conda_api import Commands, run_command
+# and when it is not needed, we do this:
+#   from conda_token.conda_api import Commands
+#   from conda.cli.main import main as run_command
+
+
+import subprocess
+
+
+class Commands:
+    CLEAN = "clean"
+    CONFIG = "config"
+    INSTALL = "install"
+    LIST = "list"
+    REMOVE = "remove"
+    SEARCH = "search"
+
+
+def run_command(*args, use_exception_handler=False):
+    args = ("python", "-m", "conda") + args
+    proc = subprocess.run(args, capture_output=True, text=True)
+    return proc.stdout, proc.stderr, proc.returncode

--- a/src/anaconda_auth/_conda/conda_api.py
+++ b/src/anaconda_auth/_conda/conda_api.py
@@ -3,9 +3,9 @@
 # the run_command functionality needed for tests. But most of the internal
 # uses of run_command do not require this overhead and are better served
 # working in process. So when subprocess is needed, we do this:
-#   from conda_token.conda_api import Commands, run_command
+#   from anaconda_auth._conda.conda_api import Commands, run_command
 # and when it is not needed, we do this:
-#   from conda_token.conda_api import Commands
+#   from anaconda_auth._conda.conda_api import Commands
 #   from conda.cli.main import main as run_command
 
 

--- a/src/anaconda_auth/_conda/repo_config.py
+++ b/src/anaconda_auth/_conda/repo_config.py
@@ -30,6 +30,7 @@ from conda.models.channel import Channel
 from packaging import version
 from rich.prompt import Confirm
 
+from anaconda_auth._conda.conda_api import Commands
 from anaconda_auth._conda.condarc import CondaRC
 from anaconda_cli_base import console
 
@@ -43,13 +44,6 @@ ARCHIVE_CHANNELS = ["free", "mro-archive", "pro"]
 user_rc_path = abspath(expanduser("~/.condarc"))
 escaped_user_rc_path = user_rc_path.replace("%", "%%")
 escaped_sys_rc_path = abspath(join(sys.prefix, ".condarc")).replace("%", "%%")
-
-
-class Commands:
-    """Names for conda commands used."""
-
-    CONFIG = "config"
-    CLEAN = "clean"
 
 
 class CondaTokenError(RuntimeError):

--- a/src/anaconda_auth/_conda/repo_config.py
+++ b/src/anaconda_auth/_conda/repo_config.py
@@ -61,7 +61,10 @@ class CondaVersionWarning(UserWarning):
 
 
 def can_restore_free_channel() -> bool:
-    return CONDA_VERSION >= version.parse("4.7.0")
+    # restore_free_channel was removed in conda 25.9.0
+    return CONDA_VERSION >= version.parse("4.7.0") and CONDA_VERSION < version.parse(
+        "25.9.0"
+    )
 
 
 def get_ssl_verify() -> bool:

--- a/tests/conda_token/conftest.py
+++ b/tests/conda_token/conftest.py
@@ -6,9 +6,8 @@ import pytest
 
 conda = pytest.importorskip("conda")
 
-from conda.cli.python_api import Commands  # noqa: E402
-from conda.cli.python_api import run_command  # noqa: E402
-
+from anaconda_auth._conda.conda_api import Commands  # noqa: E402
+from anaconda_auth._conda.conda_api import run_command  # noqa: E402
 from anaconda_auth._conda.repo_config import clean_index  # noqa: E402
 from anaconda_auth._conda.repo_config import token_remove  # noqa: E402
 from anaconda_auth._conda.repo_config import token_set  # noqa: E402

--- a/tests/conda_token/test_conda.py
+++ b/tests/conda_token/test_conda.py
@@ -2,10 +2,10 @@ import json
 from textwrap import dedent
 
 import pytest
-from conda.cli.python_api import Commands
-from conda.cli.python_api import run_command
 from packaging.version import parse
 
+from anaconda_auth._conda.conda_api import Commands
+from anaconda_auth._conda.conda_api import run_command
 from anaconda_auth._conda.repo_config import CONDA_VERSION
 
 

--- a/tests/conda_token/test_token.py
+++ b/tests/conda_token/test_token.py
@@ -2,12 +2,12 @@ from urllib.parse import urlparse
 from urllib.parse import urlunparse
 
 import pytest
-from conda.cli.python_api import Commands
-from conda.cli.python_api import run_command
 from conda.gateways.connection.session import CondaHttpAuth
 from conda.gateways.connection.session import CondaSession
 from requests import HTTPError
 
+from anaconda_auth._conda.conda_api import Commands
+from anaconda_auth._conda.conda_api import run_command
 from anaconda_auth._conda.repo_config import CondaTokenError
 from anaconda_auth._conda.repo_config import get_ssl_verify
 from anaconda_auth._conda.repo_config import token_list


### PR DESCRIPTION
## Summary

[CLI-7](https://anaconda.atlassian.net/browse/CLI-7)

Replaces references to the `conda.cli.python_api`, which was removed in conda 25.9.0.

We replace this instead with a minimal replacement that uses the `subprocess` module.

[CLI-7]: https://anaconda.atlassian.net/browse/CLI-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ