### PR TITLE
chore(deps): Update conda-token lower bound to force the metapackage

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -32,7 +32,7 @@ outputs:
         {% endfor %}
       run_constrained:
         - {{ pin_subpackage("anaconda-cloud-auth", exact=True) }}
-        - conda-token >=0.6.0
+        - conda-token >=0.7.0
     test:
       imports:
         - anaconda_auth


### PR DESCRIPTION
## Summary

[CLI-9](https://anaconda.atlassian.net/browse/CLI-9)

Updates the dev recipe with the new `run_constrained` specification for `conda-token >=0.7.0` for the upcoming metapackage release.

[CLI-9]: https://anaconda.atlassian.net/browse/CLI-9?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ