### PR TITLE
feat: Keyring path config

### DIFF
--- a/src/anaconda_auth/cli.py
+++ b/src/anaconda_auth/cli.py
@@ -498,6 +498,7 @@ def sites_show(
         "client_id",
         "hash_hostname",
         "keyring",
+        "keyring_path",
         "preferred_token_storage",
         "login_success_path",
         "login_error_path",

--- a/src/anaconda_auth/config.py
+++ b/src/anaconda_auth/config.py
@@ -1,6 +1,8 @@
 import re
 import warnings
 from functools import cached_property
+from os.path import expandvars
+from pathlib import Path
 from typing import Any
 from typing import ClassVar
 from typing import Dict
@@ -21,6 +23,7 @@ from urllib.parse import urlparse
 from pydantic import BaseModel
 from pydantic import Field
 from pydantic import RootModel
+from pydantic import field_serializer
 from pydantic import field_validator
 from pydantic import model_validator
 from pydantic.fields import FieldInfo
@@ -60,6 +63,7 @@ class AnacondaAuthSite(BaseModel):
     auth_domain_override: Optional[str] = None
     api_key: Optional[str] = None
     keyring: Optional[Dict[str, Dict[str, str]]] = None
+    keyring_path: Path = Path("~/.anaconda/keyring").expanduser()
     ssl_verify: Union[bool, str] = True
     extra_headers: Optional[Union[Dict[str, str], str]] = None
     client_id: str = "b4ad7f1d-c784-46b5-a9fe-106e50441f5a"
@@ -78,6 +82,15 @@ class AnacondaAuthSite(BaseModel):
     env_manager_package: str = "anaconda-env-manager"
     env_manager_version: Optional[str] = None
     _merged: bool = False
+
+    @field_validator("keyring_path", mode="before")
+    @classmethod
+    def expand_keyring_path(cls, value: str) -> Path:
+        return Path(expandvars(value)).expanduser()
+
+    @field_serializer("keyring_path")
+    def serialize_path(self, path: Path, _info) -> str:
+        return str(path.absolute())
 
     @field_validator("env_manager_version", mode="before")
     @classmethod

--- a/src/anaconda_auth/config.py
+++ b/src/anaconda_auth/config.py
@@ -23,8 +23,8 @@ from urllib.parse import urlparse
 from pydantic import BaseModel
 from pydantic import Field
 from pydantic import RootModel
-from pydantic import field_serializer
 from pydantic import field_validator
+from pydantic import model_serializer
 from pydantic import model_validator
 from pydantic.fields import FieldInfo
 from pydantic_settings import BaseSettings
@@ -88,9 +88,16 @@ class AnacondaAuthSite(BaseModel):
     def expand_keyring_path(cls, value: str) -> Path:
         return Path(expandvars(value)).expanduser()
 
-    @field_serializer("keyring_path")
-    def serialize_path(self, path: Path, _info) -> str:
-        return str(path.absolute())
+    @model_serializer(mode="wrap")
+    def _serialize_model(self, handler: Any) -> dict:
+        # model_serializer (not field_serializer) so exclude_defaults compares
+        # raw Path vs Path default, not serialized str vs Path default.
+        data = handler(self)
+        if "keyring_path" in data:
+            kp = data["keyring_path"]
+            if isinstance(kp, Path):
+                data["keyring_path"] = str(kp.absolute())
+        return data
 
     @field_validator("env_manager_version", mode="before")
     @classmethod

--- a/src/anaconda_auth/token.py
+++ b/src/anaconda_auth/token.py
@@ -139,7 +139,10 @@ class NavigatorFallback(KeyringBackend):
 
 class AnacondaKeyring(KeyringBackend):
     name = "token AnacondaKeyring"  # Pinning name explicitly instead of relying on module.submodule automatic naming convention.
-    keyring_path = Path("~/.anaconda/keyring").expanduser()
+
+    @classproperty
+    def keyring_path(cls) -> Path:
+        return AnacondaAuthConfig().keyring_path
 
     @classproperty
     def priority(cls) -> float:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -620,7 +620,7 @@ def test_keyring_path_serialization_excludes_default() -> None:
 
     custom = AnacondaAuthSite.model_validate({"keyring_path": "/tmp/custom/keyring"})
     dump = custom.model_dump(exclude_defaults=True)
-    assert dump["keyring_path"] == "/tmp/custom/keyring"
+    assert dump["keyring_path"] == str(Path("/tmp/custom/keyring").absolute())
     assert isinstance(dump["keyring_path"], str)
 
     roundtrip = AnacondaAuthSite.model_validate(site.model_dump())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -594,3 +594,31 @@ def test_ssl_verify_toml_global_values(
 def test_env_mgr_version(version: str, expected: str) -> None:
     config = AnacondaAuthSite(env_manager_version=version)
     assert config.env_manager_version == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("~/.anaconda/keyring", Path("~/.anaconda/keyring").expanduser()),
+        ("/tmp/custom/keyring", Path("/tmp/custom/keyring")),
+        ("$HOME/.keyring", Path.home() / ".keyring"),
+    ],
+)
+def test_keyring_path_validation(value: str, expected: Path) -> None:
+    site = AnacondaAuthSite.model_validate({"keyring_path": value})
+    assert site.keyring_path == expected
+    assert isinstance(site.keyring_path, Path)
+
+
+def test_keyring_path_serialization_excludes_default() -> None:
+    site = AnacondaAuthSite()
+    dump = site.model_dump(exclude_defaults=True)
+    assert "keyring_path" not in dump
+
+    custom = AnacondaAuthSite.model_validate({"keyring_path": "/tmp/custom/keyring"})
+    dump = custom.model_dump(exclude_defaults=True)
+    assert dump["keyring_path"] == "/tmp/custom/keyring"
+    assert isinstance(dump["keyring_path"], str)
+
+    roundtrip = AnacondaAuthSite.model_validate(site.model_dump())
+    assert "keyring_path" not in roundtrip.model_dump(exclude_defaults=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -601,10 +601,13 @@ def test_env_mgr_version(version: str, expected: str) -> None:
     [
         ("~/.anaconda/keyring", Path("~/.anaconda/keyring").expanduser()),
         ("/tmp/custom/keyring", Path("/tmp/custom/keyring")),
-        ("$HOME/.keyring", Path.home() / ".keyring"),
+        ("$KEYRING_ROOT/keyring", Path("/tmp/anaconda/keyring")),
     ],
 )
-def test_keyring_path_validation(value: str, expected: Path) -> None:
+def test_keyring_path_validation(
+    value: str, expected: Path, monkeypatch: MonkeyPatch
+) -> None:
+    monkeypatch.setenv("KEYRING_ROOT", "/tmp/anaconda")
     site = AnacondaAuthSite.model_validate({"keyring_path": value})
     assert site.keyring_path == expected
     assert isinstance(site.keyring_path, Path)

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -69,11 +69,11 @@ def test_preferred_token_storage(monkeypatch: MonkeyPatch) -> None:
     )
 
 
-def test_anaconda_keyring_save_delete(tmp_path: Path) -> None:
+def test_anaconda_keyring_save_delete(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    keyring_path = tmp_path / "keyring"
+    monkeypatch.setenv("ANACONDA_AUTH_KEYRING_PATH", str(keyring_path))
     from anaconda_auth.token import AnacondaKeyring
 
-    fn = tmp_path / "keyring"
-    AnacondaKeyring.keyring_path = fn
     assert AnacondaKeyring.viable
 
     anaconda_keyring = AnacondaKeyring()
@@ -113,14 +113,14 @@ def test_anaconda_keyring_save_delete(tmp_path: Path) -> None:
     assert anaconda_keyring.get_password("s3", "u4") is None
 
 
-def test_anaconda_keyring_empty(tmp_path: Path) -> None:
+def test_anaconda_keyring_empty(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     fn = tmp_path / "keyring"
     fn.touch()
     assert fn.exists()
 
-    from anaconda_auth.token import AnacondaKeyring
+    monkeypatch.setenv("ANACONDA_AUTH_KEYRING_PATH", str(fn))
 
-    AnacondaKeyring.keyring_path = fn
+    from anaconda_auth.token import AnacondaKeyring
 
     anaconda_keyring = AnacondaKeyring()
     assert anaconda_keyring.get_password("s", "u") is None
@@ -129,22 +129,27 @@ def test_anaconda_keyring_empty(tmp_path: Path) -> None:
         anaconda_keyring.delete_password("s", "u")
 
 
-def test_anaconda_keyring_not_writable(tmp_path: Path) -> None:
+def test_anaconda_keyring_not_writable(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    keyring_path = tmp_path / "keyring"
+    monkeypatch.setenv("ANACONDA_AUTH_KEYRING_PATH", str(keyring_path))
     from anaconda_auth.token import AnacondaKeyring
 
-    AnacondaKeyring.keyring_path = tmp_path / "keyring"
     AnacondaKeyring.keyring_path.touch()
     AnacondaKeyring.keyring_path.chmod(0x444)
 
     assert not AnacondaKeyring.viable
 
 
-def test_anaconda_keyring_dir_not_a_dir(tmp_path: Path) -> None:
-    from anaconda_auth.token import AnacondaKeyring
-
+def test_anaconda_keyring_dir_not_a_dir(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
     keyring_dir = tmp_path / "anaconda"
     keyring_dir.touch()
-    AnacondaKeyring.keyring_path = keyring_dir / "keyring"
+    kerying_path = keyring_dir / "keyring"
+    monkeypatch.setenv("ANACONDA_AUTH_KEYRING_PATH", str(kerying_path))
+    from anaconda_auth.token import AnacondaKeyring
 
     assert not AnacondaKeyring.viable
 

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -147,8 +147,8 @@ def test_anaconda_keyring_dir_not_a_dir(
 ) -> None:
     keyring_dir = tmp_path / "anaconda"
     keyring_dir.touch()
-    kerying_path = keyring_dir / "keyring"
-    monkeypatch.setenv("ANACONDA_AUTH_KEYRING_PATH", str(kerying_path))
+    keyring_path = keyring_dir / "keyring"
+    monkeypatch.setenv("ANACONDA_AUTH_KEYRING_PATH", str(keyring_path))
     from anaconda_auth.token import AnacondaKeyring
 
     assert not AnacondaKeyring.viable


### PR DESCRIPTION
The path to the keyring file (default is `~/.anaconda/keyring`) is now brought into the full configuration system

* env var: `ANACONDA_AUTH_KEYRING_PATH`
* config.toml: `keyring_path = </path/to/keyring/file>` in `[plugin.auth]` or `[sites.<site>]` tables

When the keyring_path configuration value is loaded it will expand env vars and `~`.