### PR TITLE
fix: Fall back to env var when keyring lookup fails

### DIFF
--- a/src/anaconda_auth/_conda/auth_handler.py
+++ b/src/anaconda_auth/_conda/auth_handler.py
@@ -216,12 +216,29 @@ class AnacondaAuthHandler(ChannelAuthBase):
                     return AccessCredential(token, CredentialType.REPO_TOKEN)
         return None
 
+    @staticmethod
+    def _load_token_from_env(
+        token_domain: str,
+        credential_type: CredentialType,
+    ) -> Optional[AccessCredential]:
+        """Attempt to load the token from environment variable via config.
+
+        This serves as a fallback when the keyring lookup fails, checking if
+        ANACONDA_AUTH_API_KEY env var is set.
+
+        """
+        config = AnacondaAuthConfig(domain=token_domain)
+        if config.api_key and credential_type == CredentialType.API_KEY:
+            return AccessCredential(config.api_key, CredentialType.API_KEY)
+        return None
+
     @lru_cache
     def _load_token(self, url: str) -> AccessCredential:
         """Load the appropriate token based on URL matching.
 
         First, attempts to load from the keyring. If that fails, we attempt
-        to load the legacy repo token via conda-token.
+        to load from the ANACONDA_AUTH_API_KEY env var, then fall back to
+        the legacy repo token via conda-token.
 
         Cached for performance.
 
@@ -239,6 +256,8 @@ class AnacondaAuthHandler(ChannelAuthBase):
         if token := self._load_token_from_keyring(
             token_domain, credential_type, parsed_url
         ):
+            return token
+        elif token := self._load_token_from_env(token_domain, credential_type):
             return token
         elif token := self._load_token_via_conda_token(parsed_url):
             return token

--- a/tests/test_conda_plugins.py
+++ b/tests/test_conda_plugins.py
@@ -183,6 +183,36 @@ def test_get_token_missing(handler):
     assert token == AccessCredential(None, CredentialType.REPO_TOKEN)
 
 
+@pytest.mark.usefixtures("mocked_empty_conda_token")
+def test_get_token_from_env_var_when_keyring_empty(handler, monkeypatch):
+    """When keyring lookup fails, the handler should fall back to ANACONDA_AUTH_API_KEY env var."""
+    monkeypatch.setenv("ANACONDA_AUTH_API_KEY", "my-env-var-api-key")
+
+    # Clear the lru_cache to ensure fresh lookup
+    handler._load_token.cache_clear()
+
+    token = handler._load_token(
+        "https://repo.anaconda.com/pkgs/main/noarch/repodata.json"
+    )
+    assert token == AccessCredential("my-env-var-api-key", CredentialType.API_KEY)
+
+
+@pytest.mark.usefixtures("mocked_token_info_with_api_key")
+def test_keyring_takes_precedence_over_env_var(handler, monkeypatch):
+    """Keyring token should be used even when ANACONDA_AUTH_API_KEY env var is set."""
+    monkeypatch.setenv("ANACONDA_AUTH_API_KEY", "my-env-var-api-key")
+    monkeypatch.setenv("ANACONDA_AUTH_USE_UNIFIED_REPO_API_KEY", "True")
+
+    # Clear the lru_cache to ensure fresh lookup
+    handler._load_token.cache_clear()
+
+    token = handler._load_token(
+        "https://repo.anaconda.cloud/repo/my-org/my-channel/noarch/repodata.json"
+    )
+    # Should use keyring token, not env var
+    assert token == AccessCredential("my-test-api-key", CredentialType.API_KEY)
+
+
 @pytest.mark.usefixtures("mocked_token_info")
 def test_inject_header_during_request(session, url, monkeypatch):
     # Set up a dummy function that will capture the PreparedRequest without sending it.


### PR DESCRIPTION
## Summary
- Adds `_load_token_from_env()` method to check `ANACONDA_AUTH_API_KEY` env var when keyring lookup fails
- Updates `_load_token()` to check env var as fallback between keyring and conda-token lookups
- Fixes issue where tokens set via environment variable weren't being picked up by the auth handler

## Test plan
- [ ] Set `ANACONDA_AUTH_API_KEY` env var without any keyring token stored
- [ ] Verify auth handler uses the env var token for requests
- [ ] Verify keyring tokens still take precedence when present

🤖 Generated with [Claude Code](https://claude.com/claude-code)