### PR TITLE
[fix] async account attr

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install testing dependencies
         run: |
           conda install conda-forge::tox
-          pip install tox-conda tox-gh-actions
+          pip install "virtualenv<21" tox-conda tox-gh-actions
       - name: Test with tox
         env:
           CE_TOKEN: ${{ secrets.TEST_REPO_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,8 @@ jobs:
           miniconda-version: latest
       - name: Install testing dependencies
         run: |
-          conda install conda-forge::tox
-          pip install "virtualenv<21" tox-conda tox-gh-actions
+          conda install conda-forge::tox "conda-forge::virtualenv<21"
+          pip install tox-conda tox-gh-actions
       - name: Test with tox
         env:
           CE_TOKEN: ${{ secrets.TEST_REPO_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ anaconda_auth = "anaconda_auth.panel:AnacondaLoginHandler"
 dev = [
   "mypy",
   "pytest",
+  "pytest-asyncio",
   "pytest-cov",
   "pytest-mock",
   "requests-mock",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,6 +246,7 @@ deps =
     pydantic1: pydantic <2.0
     pydantic2: pydantic >=2.0
 conda_deps =
+    pip
     anaconda-anon-usage
     anaconda-client
     # Optionally install conda to test plugins
@@ -263,9 +264,11 @@ commands = pytest {posargs}
 
 [testenv:.package]
 conda_deps =
+    pip
 
 [testenv:mypy]
 conda_deps =
+    pip
 deps =
     mypy
     pytest

--- a/src/anaconda_auth/async_client.py
+++ b/src/anaconda_auth/async_client.py
@@ -18,23 +18,22 @@ class AsyncBaseClient(httpx.AsyncClient, BaseClient):  # type: ignore
            from the sync client: headers, verify, cert, base_url and auth.
         kwargs: passed to BaseClient and its requests.Session superclass
         """
-        sync_client = BaseClient(**kwargs)  # type: ignore
-        self._account = sync_client.account
-        self.config = sync_client.config
-        self.api_version = sync_client.api_version
+        self._sync_client = BaseClient(**kwargs)  # type: ignore
+        self.config = self._sync_client.config
+        self.api_version = self._sync_client.api_version
 
         super().__init__(
-            headers=sync_client.headers,  # type: ignore
-            verify=sync_client._ssl,  # type: ignore
-            cert=sync_client.config.client_cert,
-            base_url=sync_client._base_uri,
-            auth=sync_client.auth,  # type: ignore
+            headers=self._sync_client.headers,  # type: ignore
+            verify=self._sync_client._ssl,  # type: ignore
+            cert=self._sync_client.config.client_cert,
+            base_url=self._sync_client._base_uri,
+            auth=self._sync_client.auth,  # type: ignore
             **(httpx_kwargs or {}),
         )
 
     @cached_property
     def account(self) -> dict:
-        return self._account
+        return self._sync_client.account
 
     async def request(  # type: ignore
         self,

--- a/src/anaconda_auth/cli.py
+++ b/src/anaconda_auth/cli.py
@@ -423,10 +423,7 @@ def auth_info(at: Annotated[Optional[str], typer.Option()] = None) -> None:
     """Display information about the currently signed-in user"""
     _override_default_site(at)
     client = BaseClient()
-    response = client.get("/api/account")
-    response.raise_for_status()
-    console.print(f"Your info ({client.config.domain}):")
-    console.print_json(data=response.json(), indent=2, sort_keys=True)
+    console.print_json(data=client.account, indent=2, sort_keys=True)
 
 
 @app.command(name="api-key")

--- a/src/anaconda_auth/client.py
+++ b/src/anaconda_auth/client.py
@@ -223,8 +223,27 @@ class BaseClient(requests.Session):
     @cached_property
     def account(self) -> dict:
         res = self.get("/api/account")
-        res.raise_for_status()
-        account = res.json()
+        if not res.ok and "Authorization" not in res.request.headers:
+            account = {
+                "user": {
+                    "id": None,
+                    "email": None,
+                    "username": "",
+                    "first_name": "",
+                    "last_name": "",
+                },
+                "profile": {
+                    "is_confirmed": False,
+                    "is_disabled": False,
+                    "is_consented": False,
+                },
+                "subscriptions": [],
+            }
+        else:
+            res.raise_for_status()
+            account = res.json()
+
+        account["domain"] = self.config.domain
         return account
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ from dotenv import load_dotenv
 from keyring.backend import KeyringBackend
 from pytest import MonkeyPatch
 from pytest_mock import MockerFixture
+from requests.exceptions import HTTPError
 from requests_mock import Mocker as RequestMocker
 from typer.testing import CliRunner
 
@@ -244,9 +245,15 @@ class MockResponse:
     def json(self) -> dict[str, Any]:
         return self.json_data or {}
 
-    def raise_for_status(self) -> None:
-        from requests.exceptions import HTTPError
+    @property
+    def ok(self) -> bool:
+        try:
+            self.raise_for_status()
+        except HTTPError:
+            return False
+        return True
 
+    def raise_for_status(self) -> None:
         if self.status_code >= 400:
             raise HTTPError(f"Mocked HTTP error: {self.status_code}")
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -12,6 +12,8 @@ def test_async_client_init_without_credentials(monkeypatch) -> None:
     monkeypatch.delenv("ANACONDA_AUTH_API_KEY", raising=False)
     client = AsyncBaseClient()
     assert isinstance(client, AsyncBaseClient)
+    assert client.account["user"]["id"] is None
+    assert client.account["domain"] == client.config.domain
 
 
 @pytest.fixture()

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -8,6 +8,12 @@ from .conftest import MockedRequest
 from .conftest import MockResponse
 
 
+def test_async_client_init_without_credentials(monkeypatch) -> None:
+    monkeypatch.delenv("ANACONDA_AUTH_API_KEY", raising=False)
+    client = AsyncBaseClient()
+    assert isinstance(client, AsyncBaseClient)
+
+
 @pytest.fixture()
 def mocked_request(mocker):
     """A mocked request, returning a custom response."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -25,6 +25,12 @@ from .conftest import is_conda_installed
 HERE = os.path.dirname(__file__)
 
 
+def test_client_init_without_credentials(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.delenv("ANACONDA_AUTH_API_KEY", raising=False)
+    client = BaseClient()
+    assert isinstance(client, BaseClient)
+
+
 @pytest.mark.integration
 @pytest.mark.usefixtures("disable_dot_env")
 def test_login_required_error(monkeypatch: MonkeyPatch) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -29,6 +29,8 @@ def test_client_init_without_credentials(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.delenv("ANACONDA_AUTH_API_KEY", raising=False)
     client = BaseClient()
     assert isinstance(client, BaseClient)
+    assert client.account["user"]["id"] is None
+    assert client.account["domain"] == client.config.domain
 
 
 @pytest.mark.integration


### PR DESCRIPTION
edit: I've now added an anonymous `.account` response that will also be shown for `anaconda whoami`

<img width="318" height="308" alt="Screenshot 2026-05-01 at 09 43 20" src="https://github.com/user-attachments/assets/5c65cca2-db8a-42e8-84fb-7c46e606b101" />



The sync client can load with missing† or bad credentials and only when `.account` is accessed will an error be raised.

This PR provides a lazy load of `.account`.

Here's the existing behavior

```python
[ins] In [1]: from anaconda_auth.client import BaseClient

[ins] In [2]: c = BaseClient(api_key='foo')

[ins] In [3]: c.account
---------------------------------------------------------------------------
HTTPError                                 Traceback (most recent call last)
Cell In[3], line 1
```

The async client attempts to replicate the `.account` property but ends up calling the sync property on init and so causes the error immediately

```python
[ins] In [1]: from anaconda_auth.async_client import AsyncBaseClient

[ins] In [2]: c = AsyncBaseClient(api_key='foo')
---------------------------------------------------------------------------
HTTPError                                 Traceback (most recent call last)
```

†credentials can come from api_key= init kwarg, env variable, or keyring.