### PR TITLE
fix: Add special-case handling for channels that require API keys and conflict w/ wildcard

### DIFF
--- a/src/anaconda_auth/_conda/auth_handler.py
+++ b/src/anaconda_auth/_conda/auth_handler.py
@@ -32,6 +32,10 @@ from anaconda_auth.token import TokenInfo
 
 URI_PREFIX = "/repo/"
 
+# Temporary special case: main-x channel requires API_KEY instead of REPO_TOKEN
+# TODO: Remove this when the default for repo.anaconda.cloud wildcard changes
+MAIN_X_PATH_PREFIX = "/repo/main-x/"
+
 
 class ResponseHook(Protocol):
     # Type alias/protocol for requests response hook
@@ -137,6 +141,13 @@ class AnacondaAuthHandler(ChannelAuthBase):
         # For specific channel domains, we override the defaults
         if channel_domain in TOKEN_DOMAIN_MAP:
             token_domain, credential_type, _ = TOKEN_DOMAIN_MAP[channel_domain]
+
+        # Special case: main-x channel on repo.anaconda.cloud requires API_KEY
+        if (
+            channel_domain == "repo.anaconda.cloud"
+            and parsed_url.path.lower().startswith(MAIN_X_PATH_PREFIX)
+        ):
+            credential_type = CredentialType.API_KEY
 
         # Allow users to override default via configuration
         config = AnacondaAuthConfig(domain=token_domain)

--- a/tests/test_conda_plugins.py
+++ b/tests/test_conda_plugins.py
@@ -467,3 +467,54 @@ def test_load_token_domain_user_provided_credential_type_override_invalid(
 
     with pytest.raises(AnacondaAuthError):
         AnacondaAuthHandler(channel_name=channel_url)
+
+
+def test_load_token_domain_anaconda_cloud_main_x_uses_api_key(conda_search_path):
+    """The main-x channel on repo.anaconda.cloud requires API_KEY."""
+    channel_url = "https://repo.anaconda.cloud/repo/main-x"
+    handler = AnacondaAuthHandler(channel_name=channel_url)
+    url = channel_url + "/noarch/repodata.json"
+    token_domain, credential_type = handler._load_token_domain(parsed_url=urlparse(url))
+
+    assert token_domain == "anaconda.com"
+    assert credential_type == CredentialType.API_KEY
+
+
+def test_load_token_domain_anaconda_cloud_other_channels_use_repo_token(
+    conda_search_path,
+):
+    """Other channels on repo.anaconda.cloud should still use REPO_TOKEN."""
+    for channel in ["some-channel", "main", "my-org"]:
+        channel_url = f"https://repo.anaconda.cloud/repo/{channel}"
+        handler = AnacondaAuthHandler(channel_name=channel_url)
+        url = channel_url + "/noarch/repodata.json"
+        token_domain, credential_type = handler._load_token_domain(
+            parsed_url=urlparse(url)
+        )
+
+        assert token_domain == "anaconda.com"
+        assert credential_type == CredentialType.REPO_TOKEN
+
+
+@pytest.mark.parametrize(
+    "override_credential_type", [CredentialType.API_KEY, CredentialType.REPO_TOKEN]
+)
+def test_load_token_domain_main_x_user_override_takes_precedence(
+    override_credential_type, conda_search_path
+):
+    """User-provided credential_type override should take precedence over main-x special case."""
+    channel_url = "https://repo.anaconda.cloud/repo/main-x"
+    condarc = CondaRC()
+    condarc.update_channel_settings(
+        channel=channel_url + "/*",
+        auth_type="anaconda-auth",
+        credential_type=override_credential_type,
+    )
+    condarc.save()
+
+    handler = AnacondaAuthHandler(channel_name=channel_url)
+    url = channel_url + "/noarch/repodata.json"
+    token_domain, credential_type = handler._load_token_domain(parsed_url=urlparse(url))
+
+    assert token_domain == "anaconda.com"
+    assert credential_type == override_credential_type


### PR DESCRIPTION
## Summary

Some channels on repo.anaconda.cloud require API keys, however `anaconda-auth` currently defaults to repo tokens via a wildcard pattern in conda's `channel_settings`. In order to override this default, we can either add a special `channel_settings` entry, or special-case the token type lookup. In this PR, I have implemented the latter, since the lookup ordering is more sensitive. Additionally, we will change the default in the future to prefer API keys, so the current solution is temporary.

The change has been tested locally, and is also covered by new unit tests.

Jira: [CLI-546](https://anaconda.atlassian.net/browse/CLI-546)

[CLI-546]: https://anaconda.atlassian.net/browse/CLI-546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ