### PR TITLE
feat: Use device flow by default for login

### DIFF
--- a/src/anaconda_auth/config.py
+++ b/src/anaconda_auth/config.py
@@ -77,7 +77,7 @@ class AnacondaAuthSite(BaseModel):
     proxy_servers: Optional[MutableMapping[str, str]] = None
     client_cert: Optional[str] = None
     client_cert_key: Optional[str] = None
-    use_device_flow: bool = False
+    use_device_flow: bool = True
     env_manager_channel: str = "anaconda-cloud"
     env_manager_package: str = "anaconda-env-manager"
     env_manager_version: Optional[str] = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -230,6 +230,13 @@ def without_aau_token(mocker: MockerFixture) -> None:
     mocker.patch("anaconda_auth.config.AnacondaAuthSite.aau_token", None)
 
 
+class _MockRequest:
+    """Minimal mock request object for MockResponse."""
+
+    def __init__(self, headers: dict[str, str] | None = None):
+        self.headers = headers or {}
+
+
 class MockResponse:
     def __init__(
         self,
@@ -237,10 +244,12 @@ class MockResponse:
         status_code: int,
         json_data: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
+        request_headers: dict[str, str] | None = None,
     ):
         self.status_code = status_code
         self.json_data = json_data
         self.headers = headers or {}
+        self.request = _MockRequest(request_headers)
 
     def json(self) -> dict[str, Any]:
         return self.json_data or {}

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -8,8 +8,10 @@ from .conftest import MockedRequest
 from .conftest import MockResponse
 
 
-def test_async_client_init_without_credentials(monkeypatch) -> None:
+def test_async_client_init_without_credentials(monkeypatch, mocker) -> None:
     monkeypatch.delenv("ANACONDA_AUTH_API_KEY", raising=False)
+    mocked_request = MockedRequest(response_status_code=401)
+    mocker.patch("requests.Session.request", mocked_request)
     client = AsyncBaseClient()
     assert isinstance(client, AsyncBaseClient)
     assert client.account["user"]["id"] is None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -27,7 +27,7 @@ HERE = os.path.dirname(__file__)
 
 def test_login_to_api_key(mocker: MockerFixture) -> None:
     mocker.patch("anaconda_auth.actions.get_api_key", return_value="api-key")
-    mocker.patch("anaconda_auth.actions._do_auth_flow")
+    mocker.patch("anaconda_auth.actions._do_device_flow", return_value="access-token")
 
     login()
 
@@ -66,10 +66,12 @@ def test_login_ssl_verify(
 ) -> None:
     monkeypatch.setenv("ANACONDA_AUTH_SSL_VERIFY", ssl_verify_config)
     mocker.patch("anaconda_auth.actions.get_api_key", return_value=api_key)
-    do_auth_flow = mocker.patch("anaconda_auth.actions._do_auth_flow")
+    do_device_flow = mocker.patch(
+        "anaconda_auth.actions._do_device_flow", return_value="access-token"
+    )
 
     login(ssl_verify=ssl_verify_kwarg)
-    assert do_auth_flow.call_args_list[-1].kwargs["config"].ssl_verify is eq_value
+    assert do_device_flow.call_args_list[-1].kwargs["config"].ssl_verify is eq_value
 
 
 @pytest.mark.integration

--- a/tests/test_sites_cli.py
+++ b/tests/test_sites_cli.py
@@ -457,13 +457,13 @@ def test_modify_protect_secrets(
     )
     assert result.exit_code == 0
 
+    # use_device_flow = true is the default, so it's not written to the config
     assert config_toml.read_text() == dedent(
         """\
         default_site = "short-name"
 
         [sites.short-name]
         domain = "foo.local"
-        use_device_flow = true
         """
     )
 
@@ -493,6 +493,7 @@ def test_modify_keeps_ssl_verify_false(
     )
     assert result.exit_code == 0
 
+    # use_device_flow = true is the default, so it's not written to the config
     assert config_toml.read_text() == dedent(
         """\
         default_site = "short-name"
@@ -500,12 +501,12 @@ def test_modify_keeps_ssl_verify_false(
         [sites.short-name]
         domain = "foo.local"
         ssl_verify = false
-        use_device_flow = true
         """
     )
 
 
 def test_modify_preserves_default(config_toml: Path, invoke_cli: CLIInvoker) -> None:
+    # Note: use_device_flow = true is the default, so we don't need to include it
     config_toml.write_text(
         dedent(
             """\
@@ -515,7 +516,6 @@ def test_modify_preserves_default(config_toml: Path, invoke_cli: CLIInvoker) -> 
 
             [sites."foo.local"]
             domain = "foo.local"
-            use_device_flow = true
             """
         )
     )
@@ -541,6 +541,7 @@ def test_modify_preserves_default(config_toml: Path, invoke_cli: CLIInvoker) -> 
 def test_modify_preserves_default_with_no_default_flag(
     config_toml: Path, invoke_cli: CLIInvoker
 ) -> None:
+    # Note: use_device_flow = true is the default, so we don't need to include it
     config_toml.write_text(
         dedent(
             """\
@@ -550,7 +551,6 @@ def test_modify_preserves_default_with_no_default_flag(
 
             [sites."foo.local"]
             domain = "foo.local"
-            use_device_flow = true
             """
         )
     )
@@ -637,6 +637,7 @@ def test_modify_lookup_domain(config_toml: Path, invoke_cli: CLIInvoker) -> None
     )
     assert result.exit_code == 0
 
+    # use_device_flow = true is the default, so it's not written to the config
     assert config_toml.read_text() == dedent(
         """\
         default_site = "foo"
@@ -644,7 +645,6 @@ def test_modify_lookup_domain(config_toml: Path, invoke_cli: CLIInvoker) -> None
         [sites.foo]
         domain = "foo.local"
         ssl_verify = false
-        use_device_flow = true
 
         [sites.bar]
         domain = "bar.local"
@@ -904,7 +904,7 @@ def test_sites_show_default(config_toml: Path, invoke_cli: CLIInvoker) -> None:
         "proxy_servers": None,
         "client_cert": None,
         "client_cert_key": None,
-        "use_device_flow": False,
+        "use_device_flow": True,
     }
 
     assert data == expected
@@ -939,7 +939,7 @@ def test_sites_show_site(config_toml: Path, invoke_cli: CLIInvoker) -> None:
         "proxy_servers": None,
         "client_cert": None,
         "client_cert_key": None,
-        "use_device_flow": False,
+        "use_device_flow": True,
     }
 
     assert data == expected
@@ -974,7 +974,7 @@ def test_sites_show_all(config_toml: Path, invoke_cli: CLIInvoker) -> None:
             "proxy_servers": None,
             "client_cert": None,
             "client_cert_key": None,
-            "use_device_flow": False,
+            "use_device_flow": True,
         },
         "bar": {
             "domain": "bar.local",
@@ -984,7 +984,7 @@ def test_sites_show_all(config_toml: Path, invoke_cli: CLIInvoker) -> None:
             "proxy_servers": None,
             "client_cert": None,
             "client_cert_key": None,
-            "use_device_flow": False,
+            "use_device_flow": True,
         },
     }
 


### PR DESCRIPTION
## Summary

- Changes the default value of `use_device_flow` from `False` to `True` in `AnacondaAuthSite`
- Updates tests to mock `_do_device_flow` instead of `_do_auth_flow` since device flow is now the default login method
- Updates test expectations for `sites show` commands to expect `use_device_flow: True`

## Background

Device flow provides a better user experience for authentication, particularly in environments where the traditional browser-based OAuth flow may not work well (headless servers, terminals, etc.). Making it the default aligns with modern authentication best practices.

## Test plan

- [x] All existing tests updated and passing (477 passed, 16 skipped)
- [x] `test_login_to_api_key` - mocks `_do_device_flow` 
- [x] `test_login_ssl_verify` - verifies config passed correctly to device flow
- [x] `sites show` tests - expect `use_device_flow: True` in output
- [x] `sites modify` tests - `use_device_flow=true` not written to config (it's the default)