### PR TITLE
fix: Handle UnboundLocalError when token loading fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
             source $CONDA/bin/activate && conda activate build
             mkdir -p ./conda-bld
             VERSION=`hatch version` \
-            conda build \
+            conda-build \
               -c conda-forge \
               -c defaults \
               -c anaconda-cloud \

--- a/src/anaconda_auth/_conda/auth_handler.py
+++ b/src/anaconda_auth/_conda/auth_handler.py
@@ -284,7 +284,8 @@ class AnacondaAuthHandler(ChannelAuthBase):
             return f"Bearer {token.value}", token.type
         except Exception:
             # TODO(mattkram): We need to be very resilient about exceptions here for now
-            return None, token.type
+            # Return a default credential type since token may not have been assigned
+            return None, CredentialType.API_KEY
 
     def _build_response_handler(
         self,

--- a/src/anaconda_auth/adapters.py
+++ b/src/anaconda_auth/adapters.py
@@ -44,5 +44,5 @@ class _SSLContextAdapterMixin:
         )
 
 
-class HTTPAdapter(_SSLContextAdapterMixin, BaseHttpAdapter):
+class HTTPAdapter(_SSLContextAdapterMixin, BaseHttpAdapter):  # type: ignore[misc]
     pass

--- a/tests/test_conda_plugins.py
+++ b/tests/test_conda_plugins.py
@@ -518,3 +518,31 @@ def test_load_token_domain_main_x_user_override_takes_precedence(
 
     assert token_domain == "anaconda.com"
     assert credential_type == override_credential_type
+
+
+def test_build_header_handles_exception_in_load_token(mocker):
+    """Test that _build_header handles exceptions without UnboundLocalError.
+
+    When _load_token raises an exception, the except block should not try to
+    access token.type since token was never assigned.
+
+    Regression test for https://github.com/anaconda/anaconda-auth/issues/251
+    """
+    channel_url = "https://repo.anaconda.cloud/repo/my-org/my-channel"
+    handler = AnacondaAuthHandler(channel_name=channel_url)
+
+    # Mock _load_token to raise an exception (simulating IO contention in keyring)
+    mocker.patch.object(
+        handler,
+        "_load_token",
+        side_effect=Exception("Simulated keyring IO error"),
+    )
+
+    url = "https://repo.anaconda.cloud/repo/my-org/my-channel/noarch/repodata.json"
+
+    # This should not raise UnboundLocalError
+    header, credential_type = handler._build_header(url)
+
+    # When an exception occurs, we expect None header and a default credential type
+    assert header is None
+    assert credential_type == CredentialType.API_KEY


### PR DESCRIPTION
## Summary
- Fixes `UnboundLocalError` that can occur in `_build_header` when `_load_token` raises an exception before the `token` variable is assigned
- This has been observed in cases with large numbers of channels in a `custom_multichannel`, related to IO contention in the keyring library
- Returns a default credential type (`API_KEY`) in the exception handler since no credential will be attached anyway

## Test plan
- [x] Added regression test that mocks `_load_token` to raise an exception and verifies no `UnboundLocalError` occurs
- [x] All existing tests pass

Closes #251