### PR TITLE
fix: Allow pip installs in externally-managed conda environments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,6 +231,9 @@ passenv =
     ANACONDA_AUTH_DOMAIN
     ANACONDA_AUTH_CLIENT_ID
     ANACONDA_AUTH_USE_UNIFIED_REPO_API_KEY
+setenv =
+    # Allow pip to install into conda environments that are marked as externally-managed
+    conda: PIP_BREAK_SYSTEM_PACKAGES=1
 deps =
     mypy
     pytest


### PR DESCRIPTION
## Summary
- Set `PIP_BREAK_SYSTEM_PACKAGES=1` for tox conda environments to work around PEP 668 restrictions in newer conda versions
- Fixes CI failures on Windows where conda marks environments as externally-managed, blocking pip installs

## Test plan
- [ ] Verify Windows CI passes for py311-conda and other conda-based test environments