### PR TITLE
Hub 3290 org creation command and binding

### DIFF
--- a/src/anaconda_auth/cli.py
+++ b/src/anaconda_auth/cli.py
@@ -445,6 +445,21 @@ def auth_logout(at: Annotated[Optional[str], typer.Option()] = None) -> None:
     logout()
 
 
+@app.command(name="create-org")
+def auth_create_org(
+    name: Annotated[str, typer.Option(help="Organization name (slug).")],
+    title: Annotated[str, typer.Option(help="Organization display title.")],
+    at: Annotated[Optional[str], typer.Option()] = None,
+) -> None:
+    """Create a new organization."""
+    _override_default_site(at)
+    from anaconda_auth.repo import RepoAPIClient
+
+    client = RepoAPIClient()
+    org = client.create_organization(name=name, title=title)
+    console.print(f"Organization [cyan]{org.name}[/cyan] created successfully.")
+
+
 sites_app = typer.Typer(
     name="sites",
     add_completion=False,

--- a/src/anaconda_auth/repo.py
+++ b/src/anaconda_auth/repo.py
@@ -97,7 +97,7 @@ class RepoAPIClient(BaseClient):
     def create_organization(self, name: str, title: str) -> OrganizationData:
         """Create a new organization."""
         response = self.post(
-            "/api/organizations",
+            "/api/auth/organizations",
             json={"name": name, "title": title},
         )
         response.raise_for_status()
@@ -105,7 +105,7 @@ class RepoAPIClient(BaseClient):
 
     def get_organizations_for_user(self) -> list[OrganizationData]:
         """Get a list of all organizations the user belongs to."""
-        response = self.get("/api/organizations/my")
+        response = self.get("/api/auth/organizations/my")
         response.raise_for_status()
         data = response.json()
         return [OrganizationData(**item) for item in data]

--- a/src/anaconda_auth/repo.py
+++ b/src/anaconda_auth/repo.py
@@ -94,6 +94,15 @@ class RepoAPIClient(BaseClient):
         )
         return response.token
 
+    def create_organization(self, name: str, title: str) -> OrganizationData:
+        """Create a new organization."""
+        response = self.post(
+            "/api/organizations",
+            json={"name": name, "title": title},
+        )
+        response.raise_for_status()
+        return OrganizationData(**response.json())
+
     def get_organizations_for_user(self) -> list[OrganizationData]:
         """Get a list of all organizations the user belongs to."""
         response = self.get("/api/organizations/my")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -489,7 +489,7 @@ def user_has_one_org(
     requests_mock: RequestMocker, org_name: str, business_org_id: UUID
 ) -> TokenCreateResponse:
     requests_mock.get(
-        "https://anaconda.com/api/organizations/my",
+        "https://anaconda.com/api/auth/organizations/my",
         json=[
             {
                 "id": str(business_org_id),
@@ -511,7 +511,7 @@ def user_has_multiple_orgs(
 ) -> TokenCreateResponse:
     first_id = uuid4()
     requests_mock.get(
-        "https://anaconda.com/api/organizations/my",
+        "https://anaconda.com/api/auth/organizations/my",
         json=[
             {
                 "id": str(first_id),
@@ -538,7 +538,7 @@ def user_has_no_orgs(
     requests_mock: RequestMocker, user_has_no_subscriptions: None
 ) -> list[OrganizationData]:
     requests_mock.get(
-        "https://anaconda.com/api/organizations/my",
+        "https://anaconda.com/api/auth/organizations/my",
         json=[],
     )
     return []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -400,7 +400,9 @@ def test_create_org(
         },
     )
 
-    result = invoke_cli(["auth", "create-org", "--name", "my-new-org", "--title", "My New Org"])
+    result = invoke_cli(
+        ["auth", "create-org", "--name", "my-new-org", "--title", "My New Org"]
+    )
     assert result.exit_code == 0
     assert "my-new-org" in result.output
     assert "created successfully" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -392,7 +392,7 @@ def test_create_org(
 
     org_id = uuid4()
     requests_mock.post(
-        "https://anaconda.com/api/organizations",
+        "https://anaconda.com/api/auth/organizations",
         json={
             "id": str(org_id),
             "name": "my-new-org",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -381,3 +381,26 @@ def test_post_login_setup_shows_warning_when_register_fails(
     warning_call = mock_print.call_args_list[-1]
     message = warning_call[0][0]
     assert "conda env-log register" in message
+
+
+@pytest.mark.usefixtures("valid_api_key")
+def test_create_org(
+    invoke_cli: CLIInvoker,
+    requests_mock,
+) -> None:
+    from uuid import uuid4
+
+    org_id = uuid4()
+    requests_mock.post(
+        "https://anaconda.com/api/organizations",
+        json={
+            "id": str(org_id),
+            "name": "my-new-org",
+            "title": "My New Org",
+        },
+    )
+
+    result = invoke_cli(["auth", "create-org", "--name", "my-new-org", "--title", "My New Org"])
+    assert result.exit_code == 0
+    assert "my-new-org" in result.output
+    assert "created successfully" in result.output

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -114,7 +114,7 @@ def test_create_organization(
     requests_mock: RequestMocker, org_name: str, business_org_id: UUID
 ) -> None:
     requests_mock.post(
-        "https://anaconda.com/api/organizations",
+        "https://anaconda.com/api/auth/organizations",
         json={
             "id": str(business_org_id),
             "name": org_name,

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -110,6 +110,28 @@ def test_get_business_organizations_for_user_only_starter(
     assert organizations == []
 
 
+def test_create_organization(
+    requests_mock: RequestMocker, org_name: str, business_org_id: UUID
+) -> None:
+    requests_mock.post(
+        "https://anaconda.com/api/organizations",
+        json={
+            "id": str(business_org_id),
+            "name": org_name,
+            "title": "My New Organization",
+        },
+    )
+    client = RepoAPIClient()
+    org = client.create_organization(name=org_name, title="My New Organization")
+    assert org == OrganizationData(
+        id=business_org_id, name=org_name, title="My New Organization"
+    )
+    assert requests_mock.last_request.json() == {
+        "name": org_name,
+        "title": "My New Organization",
+    }
+
+
 def test_issue_new_token_prints_success_message_via_client(
     org_name: str, mocker: MockerFixture, capsys: pytest.CaptureFixture
 ) -> None:


### PR DESCRIPTION
Implements an additional org creation function for private channels work. Users will have to be able to create an organization to have private channels.

This change updates some paths to `api/auth/organizations`, the newer preferred way to deal with orgs. The legacy ce-token path is preserved, going to bigbend, since the auth api does not support this. See swagger docs here https://stage.anaconda.com/api/auth/docs#/default/create_organization_organizations_post for all supported routes