### PR TITLE
fix: Login failure using truststore: forward resolved `ssl_verify` instead of raw config string

### DIFF
--- a/src/anaconda_auth/client.py
+++ b/src/anaconda_auth/client.py
@@ -210,8 +210,10 @@ class BaseClient(requests.Session):
         joined_url = self.urljoin(str(url))
 
         # Ensure we don't set `verify` twice. If it is passed as a kwarg to this method,
-        # that becomes the value. Otherwise, we use the value in `self.config.ssl_verify`.
-        kwargs.setdefault("verify", self.config.ssl_verify)
+        # that becomes the value. Otherwise, we use the resolved value from
+        # `configure_ssl()` (e.g. `True` with a mounted truststore SSLContext), not the
+        # raw config string, which `requests` would treat as a CA bundle path.
+        kwargs.setdefault("verify", self.verify)
 
         response = super().request(method, joined_url, *args, **kwargs)
 
@@ -272,7 +274,7 @@ class BaseClient(requests.Session):
         hashed = md5(self.email.encode("utf-8")).hexdigest()
         res = self.get(
             f"https://gravatar.com/avatar/{hashed}.png?size=120&d=404",
-            verify=self.config.ssl_verify,
+            verify=self.verify,
             auth=False,  # type: ignore
         )
         if res.ok:

--- a/src/anaconda_auth/device_flow.py
+++ b/src/anaconda_auth/device_flow.py
@@ -67,7 +67,7 @@ class DeviceCodeFlow:
             response = self.client.post(
                 self.config.oidc.device_authorization_endpoint,
                 data=data,
-                verify=self.config.ssl_verify,
+                verify=self.client.verify,
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
             )
             response.raise_for_status()
@@ -134,7 +134,7 @@ class DeviceCodeFlow:
         response = self.client.post(
             self.config.oidc.token_endpoint,
             data=data,
-            verify=self.config.ssl_verify,
+            verify=self.client.verify,
             headers={"Content-Type": "application/x-www-form-urlencoded"},
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import sys
 import traceback
 import warnings
 from collections import defaultdict
@@ -40,10 +39,20 @@ from anaconda_cli_base.cli import app
 
 load_dotenv()
 
-TRUSTSTORE_MIN_PYTHON = (3, 10)
+
+def _truststore_available() -> bool:
+    """Check if truststore module is available."""
+    try:
+        import truststore  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
 SKIP_IF_TRUSTSTORE_UNSUPPORTED = pytest.mark.skipif(
-    sys.version_info < TRUSTSTORE_MIN_PYTHON,
-    reason=f"truststore requires Python {'.'.join(map(str, TRUSTSTORE_MIN_PYTHON))}+",
+    not _truststore_available(),
+    reason="truststore module not available",
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import traceback
 import warnings
 from collections import defaultdict
@@ -38,6 +39,12 @@ from anaconda_auth.token import TokenInfo
 from anaconda_cli_base.cli import app
 
 load_dotenv()
+
+TRUSTSTORE_MIN_PYTHON = (3, 10)
+SKIP_IF_TRUSTSTORE_UNSUPPORTED = pytest.mark.skipif(
+    sys.version_info < TRUSTSTORE_MIN_PYTHON,
+    reason=f"truststore requires Python {'.'.join(map(str, TRUSTSTORE_MIN_PYTHON))}+",
+)
 
 
 def is_conda_installed():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -371,6 +371,39 @@ def test_login_ssl_verify_false(monkeypatch: MonkeyPatch) -> None:
 
 
 @pytest.mark.parametrize(
+    "ssl_verify, expected_verify",
+    [
+        pytest.param("truststore", True, id="truststore"),
+        pytest.param(True, True, id="true"),
+        pytest.param(False, False, id="false"),
+        pytest.param("/path/to/ca.pem", "/path/to/ca.pem", id="ca-bundle-path"),
+    ],
+)
+def test_request_forwards_resolved_verify(
+    mocked_request: MockedRequest,
+    ssl_verify: bool | str,
+    expected_verify: bool | str,
+) -> None:
+    """`request()` must forward the value resolved by `configure_ssl()`, never the
+    raw `ssl_verify` config. In particular `truststore` must become `verify=True`
+    (the truststore SSLContext does the verification); forwarding the literal string
+    makes requests treat it as a missing CA bundle path. Regression for that bug."""
+    client = BaseClient(ssl_verify=ssl_verify, api_key="foo")
+    client.get("/api/something")
+
+    assert client.verify == expected_verify
+    assert mocked_request.called_with_kwargs["verify"] == expected_verify
+
+
+def test_request_explicit_verify_kwarg_wins(mocked_request: MockedRequest) -> None:
+    """An explicit `verify=` passed by a caller is preserved over the resolved value."""
+    client = BaseClient(ssl_verify="truststore", api_key="foo")
+    client.get("/api/something", verify=False)
+
+    assert mocked_request.called_with_kwargs["verify"] is False
+
+
+@pytest.mark.parametrize(
     "hash,hostname,expected_result",
     [
         (False, "test-hostname", "test-hostname"),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -19,6 +19,7 @@ from anaconda_auth.config import AnacondaAuthSite
 from anaconda_auth.exceptions import UnknownSiteName
 from anaconda_auth.token import TokenInfo
 
+from .conftest import SKIP_IF_TRUSTSTORE_UNSUPPORTED
 from .conftest import MockedRequest
 from .conftest import is_conda_installed
 
@@ -373,7 +374,9 @@ def test_login_ssl_verify_false(monkeypatch: MonkeyPatch) -> None:
 @pytest.mark.parametrize(
     "ssl_verify, expected_verify",
     [
-        pytest.param("truststore", True, id="truststore"),
+        pytest.param(
+            "truststore", True, id="truststore", marks=SKIP_IF_TRUSTSTORE_UNSUPPORTED
+        ),
         pytest.param(True, True, id="true"),
         pytest.param(False, False, id="false"),
         pytest.param("/path/to/ca.pem", "/path/to/ca.pem", id="ca-bundle-path"),
@@ -395,6 +398,7 @@ def test_request_forwards_resolved_verify(
     assert mocked_request.called_with_kwargs["verify"] == expected_verify
 
 
+@SKIP_IF_TRUSTSTORE_UNSUPPORTED
 def test_request_explicit_verify_kwarg_wins(mocked_request: MockedRequest) -> None:
     """An explicit `verify=` passed by a caller is preserved over the resolved value."""
     client = BaseClient(ssl_verify="truststore", api_key="foo")

--- a/tests/test_device_flow.py
+++ b/tests/test_device_flow.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import pytest
+from pytest_mock import MockerFixture
+
+from anaconda_auth.config import AnacondaAuthSite
+from anaconda_auth.config import OpenIDConfiguration
+from anaconda_auth.device_flow import DeviceAuthorizationResponse
+from anaconda_auth.device_flow import DeviceCodeFlow
+
+from .conftest import MockedRequest
+
+DEVICE_AUTH_RESPONSE = {
+    "device_code": "device-code",
+    "user_code": "USER-CODE",
+    "verification_uri": "https://anaconda.com/device",
+    "verification_uri_complete": "https://anaconda.com/device?code=USER-CODE",
+    "expires_in": 60,
+    "interval": 5,
+}
+
+
+@pytest.fixture()
+def oidc_config(mocker: MockerFixture) -> None:
+    """Avoid the network round-trip to the well-known OIDC document."""
+    oidc = OpenIDConfiguration(
+        authorization_endpoint="https://auth.anaconda.com/authorize",
+        token_endpoint="https://auth.anaconda.com/token",
+        device_authorization_endpoint="https://auth.anaconda.com/device",
+    )
+    mocker.patch(
+        "anaconda_auth.config.AnacondaAuthSite.oidc",
+        new_callable=mocker.PropertyMock,
+        return_value=oidc,
+    )
+
+
+@pytest.mark.parametrize(
+    "ssl_verify, expected_verify",
+    [
+        pytest.param("truststore", True, id="truststore"),
+        pytest.param(True, True, id="true"),
+        pytest.param(False, False, id="false"),
+    ],
+)
+@pytest.mark.usefixtures("oidc_config")
+def test_initiate_device_authorization_forwards_resolved_verify(
+    mocker: MockerFixture,
+    ssl_verify: bool | str,
+    expected_verify: bool,
+) -> None:
+    """The device-authorization request must use the resolved `verify`, not the raw
+    `ssl_verify` config. With `truststore` the literal string was forwarded and
+    requests raised `invalid path: truststore`. Regression test."""
+    mocked_request = MockedRequest(
+        response_status_code=200, response_data=DEVICE_AUTH_RESPONSE
+    )
+    mocker.patch("requests.Session.request", mocked_request)
+
+    config = AnacondaAuthSite(ssl_verify=ssl_verify)
+    flow = DeviceCodeFlow(config=config)
+    flow.initiate_device_authorization()
+
+    assert mocked_request.called_with_kwargs["verify"] == expected_verify
+
+
+@pytest.mark.parametrize(
+    "ssl_verify, expected_verify",
+    [
+        pytest.param("truststore", True, id="truststore"),
+        pytest.param(True, True, id="true"),
+        pytest.param(False, False, id="false"),
+    ],
+)
+@pytest.mark.usefixtures("oidc_config")
+def test_request_token_forwards_resolved_verify(
+    mocker: MockerFixture,
+    ssl_verify: bool | str,
+    expected_verify: bool,
+) -> None:
+    """The token-polling request must likewise forward the resolved `verify`."""
+    mocked_request = MockedRequest(
+        response_status_code=200, response_data={"access_token": "access-token"}
+    )
+    mocker.patch("requests.Session.request", mocked_request)
+
+    config = AnacondaAuthSite(ssl_verify=ssl_verify)
+    flow = DeviceCodeFlow(config=config)
+    flow.authorize_response = DeviceAuthorizationResponse(**DEVICE_AUTH_RESPONSE)
+    flow._request_token()
+
+    assert mocked_request.called_with_kwargs["verify"] == expected_verify

--- a/tests/test_device_flow.py
+++ b/tests/test_device_flow.py
@@ -8,6 +8,7 @@ from anaconda_auth.config import OpenIDConfiguration
 from anaconda_auth.device_flow import DeviceAuthorizationResponse
 from anaconda_auth.device_flow import DeviceCodeFlow
 
+from .conftest import SKIP_IF_TRUSTSTORE_UNSUPPORTED
 from .conftest import MockedRequest
 
 DEVICE_AUTH_RESPONSE = {
@@ -38,7 +39,9 @@ def oidc_config(mocker: MockerFixture) -> None:
 @pytest.mark.parametrize(
     "ssl_verify, expected_verify",
     [
-        pytest.param("truststore", True, id="truststore"),
+        pytest.param(
+            "truststore", True, id="truststore", marks=SKIP_IF_TRUSTSTORE_UNSUPPORTED
+        ),
         pytest.param(True, True, id="true"),
         pytest.param(False, False, id="false"),
     ],
@@ -67,7 +70,9 @@ def test_initiate_device_authorization_forwards_resolved_verify(
 @pytest.mark.parametrize(
     "ssl_verify, expected_verify",
     [
-        pytest.param("truststore", True, id="truststore"),
+        pytest.param(
+            "truststore", True, id="truststore", marks=SKIP_IF_TRUSTSTORE_UNSUPPORTED
+        ),
         pytest.param(True, True, id="true"),
         pytest.param(False, False, id="false"),
     ],


### PR DESCRIPTION
## Problem

With `ssl_verify` set to `truststore` (`conda config --set ssl_verify truststore`, or the equivalent in `.condarc`/`anaconda` config), `anaconda login` fails:

```
OSError: Could not find a suitable TLS CA certificate bundle, invalid path: truststore
```

## Root cause

`BaseClient.configure_ssl()` already handles `truststore` correctly: it builds a `truststore.SSLContext`, mounts it on the session's HTTP adapters, and sets `self.verify = True`. Verification then happens through that mounted context.

But several call sites bypassed that resolved state and re-passed the **raw** config value `self.config.ssl_verify` (the literal string `"truststore"`) as `requests`' `verify=` argument. `requests` interprets a string as a CA-bundle file path, so it looked for a file named `truststore` — both raising the error and bypassing the truststore verification that had already been configured.

The `anaconda login` flow hits this through the device flow.

## Fix

Use the already-resolved value instead of the raw config string:

* `client.py` — central `request()` default and the avatar fetch now use `self.verify`
* `device_flow.py` — device authorization and token polling now use `self.client.verify`

Sites that were already correct are left unchanged: `async_client.py` passes the `SSLContext` object to httpx natively, and `repo_config.py` uses conda's `CondaSession`, which has independent truststore support.

## Tests

Added regression tests in the repo's existing style (`MockedRequest` patching `requests.Session.request`, parametrized over `truststore`/`True`/`False`):

* `tests/test_client.py` — `request()` forwards the resolved `verify` (truststore → `True`, CA-bundle path passed through unchanged), and an explicit caller `verify=` still wins.
* `tests/test_device_flow.py` — device authorization and token polling forward the resolved `verify`.

These assert on the `verify` value **forwarded to requests** rather than on a live request succeeding: the bug is in the argument, not the response, and `requests_mock`/the test transport never run cert verification — so a mocked-request-succeeds test would pass even with the bug present.

With the source fix reverted, exactly the 3 `truststore` cases fail and the `true`/`false` cases still pass, confirming the tests pin this specific regression without over-asserting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
