### PR TITLE
fix: forward truststore ssl_context to proxy connection pools

### DIFF
--- a/src/anaconda_auth/adapters.py
+++ b/src/anaconda_auth/adapters.py
@@ -43,6 +43,17 @@ class _SSLContextAdapterMixin:
             **pool_kwargs,
         )
 
+    def proxy_manager_for(self, proxy: str, **proxy_kwargs: Any) -> "PoolManager":
+        # ``requests``' ``proxy_manager_for`` builds a *separate* ``ProxyManager``
+        # that does not receive the pool kwargs passed to ``init_poolmanager``, so
+        # the custom ``ssl_context`` (e.g. the truststore backend) must be forwarded
+        # here too. Otherwise ``ssl_verify: truststore`` is silently ignored whenever
+        # a proxy is configured and verification falls back to the default certifi
+        # store, which has no knowledge of a TLS-inspecting proxy's CA.
+        if self._ssl_context is not None:
+            proxy_kwargs.setdefault("ssl_context", self._ssl_context)
+        return super().proxy_manager_for(proxy, **proxy_kwargs)  # type: ignore[misc]
+
 
 class HTTPAdapter(_SSLContextAdapterMixin, BaseHttpAdapter):  # type: ignore[misc]
     pass

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import pytest
 from pytest import MonkeyPatch
 
 from anaconda_auth.adapters import HTTPAdapter
@@ -58,7 +57,9 @@ def test_client_truststore_ssl_context_reaches_proxy(monkeypatch: MonkeyPatch) -
     client = BaseClient(ssl_verify="truststore", api_key="foo")
     assert client._ssl is not None
 
-    adapter = client.get_adapter("https://anaconda.com/.well-known/openid-configuration")
+    adapter = client.get_adapter(
+        "https://anaconda.com/.well-known/openid-configuration"
+    )
     proxy_manager = adapter.proxy_manager_for("http://127.0.0.1:8080")
 
     assert proxy_manager.connection_pool_kw.get("ssl_context") is client._ssl

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+from pytest import MonkeyPatch
+
+from anaconda_auth.adapters import HTTPAdapter
+from anaconda_auth.client import BaseClient
+
+from .conftest import SKIP_IF_TRUSTSTORE_UNSUPPORTED
+
+
+class _Sentinel:
+    """Stand-in for an SSLContext; identity is all the adapter cares about."""
+
+
+def test_init_poolmanager_forwards_ssl_context() -> None:
+    sentinel = _Sentinel()
+    adapter = HTTPAdapter(ssl_context=sentinel)
+
+    assert adapter.poolmanager.connection_pool_kw.get("ssl_context") is sentinel
+
+
+def test_proxy_manager_for_forwards_ssl_context() -> None:
+    """The proxy connection pool must carry the same ssl_context as the direct
+    pool. Regression for `ssl_verify: truststore` being silently dropped on the
+    proxy path because `requests` builds a separate ProxyManager that never sees
+    the adapter's pool kwargs."""
+    sentinel = _Sentinel()
+    adapter = HTTPAdapter(ssl_context=sentinel)
+
+    proxy_manager = adapter.proxy_manager_for("http://proxy:8080")
+    assert proxy_manager.connection_pool_kw.get("ssl_context") is sentinel
+
+
+def test_proxy_manager_for_no_ssl_context_unchanged() -> None:
+    """With no ssl_context (default ssl_verify True/False), the key must not be
+    injected so the default proxy path is untouched."""
+    adapter = HTTPAdapter(ssl_context=None)
+
+    proxy_manager = adapter.proxy_manager_for("http://proxy:8080")
+    assert "ssl_context" not in proxy_manager.connection_pool_kw
+
+
+def test_init_poolmanager_no_ssl_context_unchanged() -> None:
+    adapter = HTTPAdapter(ssl_context=None)
+
+    assert "ssl_context" not in adapter.poolmanager.connection_pool_kw
+
+
+@SKIP_IF_TRUSTSTORE_UNSUPPORTED
+def test_client_truststore_ssl_context_reaches_proxy(monkeypatch: MonkeyPatch) -> None:
+    """End-to-end at the client level: with `ssl_verify: truststore` and proxies
+    in the environment, the mounted https adapter forwards the truststore
+    SSLContext onto its proxy manager."""
+    monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:8080")
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:8080")
+
+    client = BaseClient(ssl_verify="truststore", api_key="foo")
+    assert client._ssl is not None
+
+    adapter = client.get_adapter("https://anaconda.com/.well-known/openid-configuration")
+    proxy_manager = adapter.proxy_manager_for("http://127.0.0.1:8080")
+
+    assert proxy_manager.connection_pool_kw.get("ssl_context") is client._ssl
+    # the direct pool must still carry it too
+    assert adapter.poolmanager.connection_pool_kw.get("ssl_context") is client._ssl


### PR DESCRIPTION
## Summary

When `ssl_verify` resolves to `truststore` and an HTTP/HTTPS proxy is in effect, `BaseClient` silently failed to use the truststore SSL backend on the proxied connection and fell back to the default certifi/OpenSSL certificate store. Behind a TLS-inspecting corporate proxy this surfaced during login as `CERTIFICATE_VERIFY_FAILED` on the OIDC discovery fetch (`.well-known/openid-configuration`) — and on every other request the client makes through the proxy. Login worked without a proxy, and worked *with* a proxy when `ssl_verify` was a CA-bundle file path instead of `truststore`.

## Root cause

`_SSLContextAdapterMixin` (in `src/anaconda_auth/adapters.py`) only overrode `init_poolmanager`, which configures the adapter's **direct-connection** `PoolManager`. When a proxy is configured, `requests` does not route through that pool manager — `HTTPAdapter.send` calls `proxy_manager_for(proxy)`, which lazily builds a **separate** `urllib3.ProxyManager`. `requests`' `proxy_manager_for` forwards only `num_pools`, `maxsize`, `block`, and explicit `proxy_kwargs`; it never sees the adapter's pool kwargs, so the custom `ssl_context` was dropped. The `ProxyManager`'s pools were then created with no `ssl_context` and urllib3 fell back to a default certifi-backed context with no knowledge of the corporate/proxy CA.

The proxy path is taken whenever `HTTP_PROXY` / `HTTPS_PROXY` are present in the environment, even if `config.proxy_servers` is `None`, because `requests` reads proxy env vars at request time.

## Relationship to #270

This is **independent** of #270 (commit `ff3567a`). That PR fixed a different truststore failure — call sites forwarding the raw `ssl_verify` string (`"truststore"`) as `requests`' `verify=`, which `requests` treats as a CA-bundle path. That fix corrected the `verify=` value on the **direct** path. This PR addresses the **proxy** path, where the `ssl_context` (not `verify`) is consumed.

## Fix

Override `proxy_manager_for` in `_SSLContextAdapterMixin` so the same `ssl_context` is forwarded into the `ProxyManager`'s pool kwargs, mirroring the existing `init_poolmanager` handling. `requests.HTTPAdapter.proxy_manager_for` accepts `**proxy_kwargs` and passes them through to the underlying connection pools, so this reaches both `https`-over-proxy and SOCKS pools.

## Tests

New `tests/test_adapters.py`:

* `proxy_manager_for` forwards the adapter's `ssl_context` into the proxy pool kwargs (and the parallel `init_poolmanager` assertion to lock in both paths).
* The `ssl_context is None` case (default `ssl_verify: True`/`False`) does **not** inject the key, so the default path is unchanged — asserted for both pool managers.
* Client-level: with `ssl_verify="truststore"` and `HTTP(S)_PROXY` set in the environment, the mounted `https://` adapter's `proxy_manager_for(...)` carries a non-`None` `ssl_context` equal to `client._ssl`.

All new tests pass; `mypy` clean on the adapter. (One unrelated pre-existing failure in `tests/test_client.py::test_anaconda_com_default_site_config` reproduces on `main` with this change stashed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
