### PR TITLE
BIG-8642: Update tos flow for env-manager

### DIFF
--- a/src/anaconda_auth/_conda/env_logger_config.py
+++ b/src/anaconda_auth/_conda/env_logger_config.py
@@ -28,6 +28,10 @@ def is_env_manager_installed(conda_path: str) -> bool:
 def install_env_manager(conda_path: str) -> tuple[bool, str]:
     """Install anaconda-env-manager into the base environment.
 
+    Note: The subprocess inherits stdio (no `-y`, no captured output) so that
+    conda's own install confirmation and the `conda-anaconda-tos` plugin's
+    Terms of Service prompt can interact with the user.
+
     Returns:
         Tuple of (success, error_message).
     """
@@ -40,11 +44,10 @@ def install_env_manager(conda_path: str) -> tuple[bool, str]:
         "--name",
         "base",
         pkg,
-        "-y",
     ]
-    proc = subprocess.run(args, capture_output=True, text=True)
+    proc = subprocess.run(args)
     if proc.returncode != 0:
-        error = proc.stderr.strip() or proc.stdout.strip()
+        error = f"conda install exited with code {proc.returncode}. See output above for details."
         logger.debug("Failed to install %s: %s", pkg, error)
         return False, error
     return True, ""

--- a/src/anaconda_auth/_conda/env_logger_config.py
+++ b/src/anaconda_auth/_conda/env_logger_config.py
@@ -27,12 +27,7 @@ def is_env_manager_installed(conda_path: str) -> bool:
 
 
 def _tos_plugin_available(conda_path: str) -> bool:
-    """Check whether the conda-anaconda-tos plugin is installed in base.
-
-    This is a local package lookup (like `is_env_manager_installed`), not a
-    live probe of the `conda tos` subcommand: `conda tos --json info` goes
-    through the plugin's `get_remote_metadata()` and does a real per-channel
-    network fetch, which is too costly just to check availability.
+    """Check whether the conda-anaconda-tos plugin is installed in base environment.
     """
     args = [conda_path, "list", "-n", "base", "conda-anaconda-tos", "--json"]
     proc = subprocess.run(args, capture_output=True, text=True)
@@ -66,6 +61,7 @@ def install_env_manager(conda_path: str) -> tuple[bool, str]:
     """
     config = AnacondaAuthConfig()
 
+    console.print("Checking channel Terms of Service...")
     if _tos_plugin_available(conda_path):
         proc = subprocess.run(
             [conda_path, "tos", "interactive"], stderr=subprocess.PIPE, text=True

--- a/src/anaconda_auth/_conda/env_logger_config.py
+++ b/src/anaconda_auth/_conda/env_logger_config.py
@@ -49,14 +49,16 @@ def install_env_manager(conda_path: str) -> tuple[bool, str]:
     """Install anaconda-env-manager into the base environment.
 
     Note:
-        ToS acceptance is best-effort: `conda tos interactive` only runs
-        when the plugin is available, and its result never blocks the
-        install. `conda install` enforces the real ToS gate itself, with a
-        proper `--json` error message if rejected. Prompts go to stdout via
-        rich (inherited, so interactivity is unaffected); stderr is
-        captured and logged instead of printed, so transient failures or a
-        prior rejection (which `conda install` will report on its own)
-        don't show up twice.
+        ToS acceptance is mostly best-effort: `conda tos interactive` only
+        runs when the plugin is available, and transient failures (e.g. a
+        network blip) never block the install—`conda install` enforces the
+        real ToS gate itself, with a proper `--json` error message. Prompts
+        go to stdout via rich (inherited, so interactivity is unaffected);
+        stderr is captured and logged instead of printed, so those failures
+        don't show up on screen. The one exception is a confirmed rejection:
+        we detect it here and fail immediately, rather than printing
+        "Installing..." right before `conda install` fails for the same
+        reason.
     """
     config = AnacondaAuthConfig()
 
@@ -69,6 +71,9 @@ def install_env_manager(conda_path: str) -> tuple[bool, str]:
             logger.debug(
                 "conda tos interactive exited %d: %s", proc.returncode, proc.stderr
             )
+            if "CondaToSRejectedError" in proc.stderr:
+                detail = proc.stderr.split("CondaToSRejectedError:", 1)[-1].strip()
+                return False, detail or "Terms of Service were rejected."
 
     console.print("Installing anaconda-env-manager...")
     pkg = f"{config.env_manager_channel}::{config.env_manager_package}{config.env_manager_version or ''}"
@@ -77,11 +82,16 @@ def install_env_manager(conda_path: str) -> tuple[bool, str]:
     if proc.returncode != 0:
         error = f"conda install exited with code {proc.returncode}."
         message = None
-        try:
-            message = json.loads(proc.stdout).get("message")
-        except (json.JSONDecodeError, TypeError, AttributeError):
-            pass
-        # Fall back to stderr if conda crashed before writing JSON output.
+        # conda writes the --json error payload to stdout, except when it's
+        # raised from a pre-command hook (e.g. a rejected ToS), in which case
+        # it lands on stderr instead. Try both before falling back to raw text.
+        for stream in (proc.stdout, proc.stderr):
+            try:
+                message = json.loads(stream).get("message")
+            except (json.JSONDecodeError, TypeError, AttributeError):
+                continue
+            if message:
+                break
         detail = message or proc.stderr.strip()
         if detail:
             error = f"{error} {detail}"

--- a/src/anaconda_auth/_conda/env_logger_config.py
+++ b/src/anaconda_auth/_conda/env_logger_config.py
@@ -25,36 +25,50 @@ def is_env_manager_installed(conda_path: str) -> bool:
         return False
 
 
+def _tos_plugin_available(conda_path: str) -> bool:
+    """Check whether conda-anaconda-tos provides the `conda tos` subcommand."""
+    proc = subprocess.run(
+        [conda_path, "tos", "--json", "info"], capture_output=True, text=True
+    )
+    if proc.returncode != 0:
+        # Non-zero could mean many things (missing plugin, renamed
+        # subcommand, bad args); log it so failures stay traceable.
+        logger.debug(
+            "conda tos probe failed (exit code %d): %s",
+            proc.returncode,
+            proc.stderr.strip() or proc.stdout.strip(),
+        )
+    return proc.returncode == 0
+
+
 def install_env_manager(conda_path: str) -> tuple[bool, str]:
     """Install anaconda-env-manager into the base environment.
 
-    Accepts Terms of Service first, then installs quietly.
-
     Note:
-        ToS acceptance runs via the plugin's own `conda tos interactive`
-        command with inherited stdio, so it can prompt the user; it's a
-        silent no-op if already accepted or if `conda-anaconda-tos` isn't
-        installed. The install runs after.
+        ToS acceptance is best-effort: `conda tos interactive` only runs
+        (with inherited stdio) when the plugin is available, and its result
+        never blocks the install. `conda install` enforces the real ToS
+        gate itself, with a proper `--json` error message if rejected.
     """
     config = AnacondaAuthConfig()
 
-    tos_args = [conda_path, "tos", "interactive"]
-    tos_proc = subprocess.run(tos_args)
-    # Exit code 2 means `tos` isn't a recognized subcommand (plugin not installed).
-    if tos_proc.returncode not in (0, 2):
-        return False, "Terms of Service were not accepted."
+    if _tos_plugin_available(conda_path):
+        subprocess.run([conda_path, "tos", "interactive"])
 
     pkg = f"{config.env_manager_channel}::{config.env_manager_package}{config.env_manager_version or ''}"
     args = [conda_path, "install", "--name", "base", pkg, "--yes", "--json"]
     proc = subprocess.run(args, capture_output=True, text=True)
     if proc.returncode != 0:
         error = f"conda install exited with code {proc.returncode}."
+        message = None
         try:
             message = json.loads(proc.stdout).get("message")
-            if message:
-                error = f"{error} {message}"
-        except (json.JSONDecodeError, AttributeError):
+        except (json.JSONDecodeError, TypeError, AttributeError):
             pass
+        # Fall back to stderr if conda crashed before writing JSON output.
+        detail = message or proc.stderr.strip()
+        if detail:
+            error = f"{error} {detail}"
         logger.debug("Failed to install %s: %s\nstderr: %s", pkg, error, proc.stderr)
         return False, error
     return True, ""

--- a/src/anaconda_auth/_conda/env_logger_config.py
+++ b/src/anaconda_auth/_conda/env_logger_config.py
@@ -28,27 +28,34 @@ def is_env_manager_installed(conda_path: str) -> bool:
 def install_env_manager(conda_path: str) -> tuple[bool, str]:
     """Install anaconda-env-manager into the base environment.
 
-    Note: The subprocess inherits stdio (no `-y`, no captured output) so that
-    conda's own install confirmation and the `conda-anaconda-tos` plugin's
-    Terms of Service prompt can interact with the user.
+    Accepts Terms of Service first, then installs quietly.
 
-    Returns:
-        Tuple of (success, error_message).
+    Note:
+        ToS acceptance runs via the plugin's own `conda tos interactive`
+        command with inherited stdio, so it can prompt the user; it's a
+        silent no-op if already accepted or if `conda-anaconda-tos` isn't
+        installed. The install runs after.
     """
     config = AnacondaAuthConfig()
 
+    tos_args = [conda_path, "tos", "interactive"]
+    tos_proc = subprocess.run(tos_args)
+    # Exit code 2 means `tos` isn't a recognized subcommand (plugin not installed).
+    if tos_proc.returncode not in (0, 2):
+        return False, "Terms of Service were not accepted."
+
     pkg = f"{config.env_manager_channel}::{config.env_manager_package}{config.env_manager_version or ''}"
-    args = [
-        conda_path,
-        "install",
-        "--name",
-        "base",
-        pkg,
-    ]
-    proc = subprocess.run(args)
+    args = [conda_path, "install", "--name", "base", pkg, "--yes", "--json"]
+    proc = subprocess.run(args, capture_output=True, text=True)
     if proc.returncode != 0:
-        error = f"conda install exited with code {proc.returncode}. See output above for details."
-        logger.debug("Failed to install %s: %s", pkg, error)
+        error = f"conda install exited with code {proc.returncode}."
+        try:
+            message = json.loads(proc.stdout).get("message")
+            if message:
+                error = f"{error} {message}"
+        except (json.JSONDecodeError, AttributeError):
+            pass
+        logger.debug("Failed to install %s: %s\nstderr: %s", pkg, error, proc.stderr)
         return False, error
     return True, ""
 

--- a/src/anaconda_auth/_conda/env_logger_config.py
+++ b/src/anaconda_auth/_conda/env_logger_config.py
@@ -27,8 +27,7 @@ def is_env_manager_installed(conda_path: str) -> bool:
 
 
 def _tos_plugin_available(conda_path: str) -> bool:
-    """Check whether the conda-anaconda-tos plugin is installed in base environment.
-    """
+    """Check whether the conda-anaconda-tos plugin is installed in base environment."""
     args = [conda_path, "list", "-n", "base", "conda-anaconda-tos", "--json"]
     proc = subprocess.run(args, capture_output=True, text=True)
     if proc.returncode != 0:

--- a/src/anaconda_auth/_conda/env_logger_config.py
+++ b/src/anaconda_auth/_conda/env_logger_config.py
@@ -3,6 +3,7 @@ import logging
 import subprocess
 
 from anaconda_auth.config import AnacondaAuthConfig
+from anaconda_cli_base.console import console
 
 logger = logging.getLogger(__name__)
 
@@ -26,19 +27,28 @@ def is_env_manager_installed(conda_path: str) -> bool:
 
 
 def _tos_plugin_available(conda_path: str) -> bool:
-    """Check whether conda-anaconda-tos provides the `conda tos` subcommand."""
-    proc = subprocess.run(
-        [conda_path, "tos", "--json", "info"], capture_output=True, text=True
-    )
+    """Check whether the conda-anaconda-tos plugin is installed in base.
+
+    This is a local package lookup (like `is_env_manager_installed`), not a
+    live probe of the `conda tos` subcommand: `conda tos --json info` goes
+    through the plugin's `get_remote_metadata()` and does a real per-channel
+    network fetch, which is too costly just to check availability.
+    """
+    args = [conda_path, "list", "-n", "base", "conda-anaconda-tos", "--json"]
+    proc = subprocess.run(args, capture_output=True, text=True)
     if proc.returncode != 0:
-        # Non-zero could mean many things (missing plugin, renamed
-        # subcommand, bad args); log it so failures stay traceable.
         logger.debug(
-            "conda tos probe failed (exit code %d): %s",
+            "conda-anaconda-tos probe failed (exit code %d): %s",
             proc.returncode,
-            proc.stderr.strip() or proc.stdout.strip(),
+            proc.stderr.strip(),
         )
-    return proc.returncode == 0
+        return False
+
+    try:
+        packages = json.loads(proc.stdout)
+        return any(pkg.get("name") == "conda-anaconda-tos" for pkg in packages)
+    except (json.JSONDecodeError, TypeError):
+        return False
 
 
 def install_env_manager(conda_path: str) -> tuple[bool, str]:
@@ -46,15 +56,26 @@ def install_env_manager(conda_path: str) -> tuple[bool, str]:
 
     Note:
         ToS acceptance is best-effort: `conda tos interactive` only runs
-        (with inherited stdio) when the plugin is available, and its result
-        never blocks the install. `conda install` enforces the real ToS
-        gate itself, with a proper `--json` error message if rejected.
+        when the plugin is available, and its result never blocks the
+        install. `conda install` enforces the real ToS gate itself, with a
+        proper `--json` error message if rejected. Prompts go to stdout via
+        rich (inherited, so interactivity is unaffected); stderr is
+        captured and logged instead of printed, so transient failures or a
+        prior rejection (which `conda install` will report on its own)
+        don't show up twice.
     """
     config = AnacondaAuthConfig()
 
     if _tos_plugin_available(conda_path):
-        subprocess.run([conda_path, "tos", "interactive"])
+        proc = subprocess.run(
+            [conda_path, "tos", "interactive"], stderr=subprocess.PIPE, text=True
+        )
+        if proc.returncode != 0:
+            logger.debug(
+                "conda tos interactive exited %d: %s", proc.returncode, proc.stderr
+            )
 
+    console.print("Installing anaconda-env-manager...")
     pkg = f"{config.env_manager_channel}::{config.env_manager_package}{config.env_manager_version or ''}"
     args = [conda_path, "install", "--name", "base", pkg, "--yes", "--json"]
     proc = subprocess.run(args, capture_output=True, text=True)

--- a/src/anaconda_auth/cli.py
+++ b/src/anaconda_auth/cli.py
@@ -357,7 +357,6 @@ def _post_login_setup(ssl_verify: Optional[Union[bool, str]] = None) -> None:
         if not install:
             return
 
-        console.print("Checking channel Terms of Service...")
         success, error = install_env_manager(conda_path)
         if not success:
             console.print(

--- a/src/anaconda_auth/cli.py
+++ b/src/anaconda_auth/cli.py
@@ -357,7 +357,7 @@ def _post_login_setup(ssl_verify: Optional[Union[bool, str]] = None) -> None:
         if not install:
             return
 
-        console.print("Installing anaconda-env-manager...")
+        console.print("Checking channel Terms of Service...")
         success, error = install_env_manager(conda_path)
         if not success:
             console.print(

--- a/tests/test_env_logger_config.py
+++ b/tests/test_env_logger_config.py
@@ -90,24 +90,6 @@ class TestInstallEnvManager:
         assert success is False
         assert "1" in error
 
-    def test_does_not_capture_output_or_pass_yes(self, mocker: MockerFixture):
-        """The subprocess must inherit stdio (no capture_output) and must not
-        pass -y, so conda's install confirmation and the conda-anaconda-tos
-        plugin's Terms of Service prompt can interact with the user.
-        """
-        from anaconda_auth._conda.env_logger_config import install_env_manager
-
-        mock_proc = mocker.MagicMock(returncode=0)
-        mock_run = mocker.patch(
-            "anaconda_auth._conda.env_logger_config.subprocess.run",
-            return_value=mock_proc,
-        )
-        install_env_manager(CONDA_PATH)
-
-        args = mock_run.call_args[0][0]
-        kwargs = mock_run.call_args[1]
-        assert "-y" not in args
-        assert "capture_output" not in kwargs
 
     def test_pins_version_when_configured(self, monkeypatch, mocker: MockerFixture):
         monkeypatch.setenv("ANACONDA_AUTH_ENV_MANAGER_VERSION", "1.2.3")

--- a/tests/test_env_logger_config.py
+++ b/tests/test_env_logger_config.py
@@ -69,10 +69,49 @@ class TestInstallEnvManager:
     def test_returns_true_on_success(self, mocker: MockerFixture):
         from anaconda_auth._conda.env_logger_config import install_env_manager
 
-        mock_proc = mocker.MagicMock(returncode=0, stderr="")
+        mock_tos_proc = mocker.MagicMock(returncode=0)
+        mock_install_proc = mocker.MagicMock(returncode=0, stdout="{}", stderr="")
+        mock_run = mocker.patch(
+            "anaconda_auth._conda.env_logger_config.subprocess.run",
+            side_effect=[mock_tos_proc, mock_install_proc],
+        )
+        success, error = install_env_manager(CONDA_PATH)
+        assert success is True
+        assert error == ""
+
+        tos_args = mock_run.call_args_list[0][0][0]
+        assert "tos" in tos_args
+        assert "interactive" in tos_args
+        # ToS step inherits stdio: no capture_output kwarg passed.
+        assert "capture_output" not in mock_run.call_args_list[0].kwargs
+
+        install_args = mock_run.call_args_list[1][0][0]
+        assert "--yes" in install_args
+        assert "--json" in install_args
+        assert mock_run.call_args_list[1].kwargs.get("capture_output") is True
+
+    def test_returns_false_when_tos_rejected(self, mocker: MockerFixture):
+        from anaconda_auth._conda.env_logger_config import install_env_manager
+
+        mock_tos_proc = mocker.MagicMock(returncode=1)
+        mock_run = mocker.patch(
+            "anaconda_auth._conda.env_logger_config.subprocess.run",
+            return_value=mock_tos_proc,
+        )
+        success, error = install_env_manager(CONDA_PATH)
+        assert success is False
+        assert "Terms of Service" in error
+        # Install should never be attempted if ToS wasn't accepted.
+        mock_run.assert_called_once()
+
+    def test_proceeds_when_tos_plugin_not_installed(self, mocker: MockerFixture):
+        from anaconda_auth._conda.env_logger_config import install_env_manager
+
+        mock_tos_proc = mocker.MagicMock(returncode=2)
+        mock_install_proc = mocker.MagicMock(returncode=0, stdout="{}", stderr="")
         mocker.patch(
             "anaconda_auth._conda.env_logger_config.subprocess.run",
-            return_value=mock_proc,
+            side_effect=[mock_tos_proc, mock_install_proc],
         )
         success, error = install_env_manager(CONDA_PATH)
         assert success is True
@@ -81,29 +120,47 @@ class TestInstallEnvManager:
     def test_returns_false_on_failure(self, mocker: MockerFixture):
         from anaconda_auth._conda.env_logger_config import install_env_manager
 
-        mock_proc = mocker.MagicMock(returncode=1)
+        mock_tos_proc = mocker.MagicMock(returncode=0)
+        mock_install_proc = mocker.MagicMock(returncode=1, stdout="{}", stderr="")
         mocker.patch(
             "anaconda_auth._conda.env_logger_config.subprocess.run",
-            return_value=mock_proc,
+            side_effect=[mock_tos_proc, mock_install_proc],
         )
         success, error = install_env_manager(CONDA_PATH)
         assert success is False
         assert "1" in error
-        assert "See output above for details." in error
+
+    def test_includes_json_error_message_on_failure(self, mocker: MockerFixture):
+        from anaconda_auth._conda.env_logger_config import install_env_manager
+
+        mock_tos_proc = mocker.MagicMock(returncode=0)
+        mock_install_proc = mocker.MagicMock(
+            returncode=1,
+            stdout='{"message": "PackagesNotFoundError: nope"}',
+            stderr="",
+        )
+        mocker.patch(
+            "anaconda_auth._conda.env_logger_config.subprocess.run",
+            side_effect=[mock_tos_proc, mock_install_proc],
+        )
+        success, error = install_env_manager(CONDA_PATH)
+        assert success is False
+        assert "PackagesNotFoundError: nope" in error
 
     def test_pins_version_when_configured(self, monkeypatch, mocker: MockerFixture):
         monkeypatch.setenv("ANACONDA_AUTH_ENV_MANAGER_VERSION", "1.2.3")
 
         from anaconda_auth._conda.env_logger_config import install_env_manager
 
-        mock_proc = mocker.MagicMock(returncode=0, stderr="")
+        mock_tos_proc = mocker.MagicMock(returncode=0)
+        mock_install_proc = mocker.MagicMock(returncode=0, stdout="{}", stderr="")
         mock_run = mocker.patch(
             "anaconda_auth._conda.env_logger_config.subprocess.run",
-            return_value=mock_proc,
+            side_effect=[mock_tos_proc, mock_install_proc],
         )
         install_env_manager(CONDA_PATH)
 
-        args = mock_run.call_args[0][0]
+        args = mock_run.call_args_list[1][0][0]
         assert "anaconda-cloud::anaconda-env-manager=1.2.3" in args
 
     def test_uses_custom_channel(self, monkeypatch, mocker: MockerFixture):
@@ -111,29 +168,31 @@ class TestInstallEnvManager:
 
         from anaconda_auth._conda.env_logger_config import install_env_manager
 
-        mock_proc = mocker.MagicMock(returncode=0, stderr="")
+        mock_tos_proc = mocker.MagicMock(returncode=0)
+        mock_install_proc = mocker.MagicMock(returncode=0, stdout="{}", stderr="")
         mock_run = mocker.patch(
             "anaconda_auth._conda.env_logger_config.subprocess.run",
-            return_value=mock_proc,
+            side_effect=[mock_tos_proc, mock_install_proc],
         )
         install_env_manager(CONDA_PATH)
 
-        args = mock_run.call_args[0][0]
-        assert "my-channel::anaconda-env-manager" in args
+        install_args = mock_run.call_args_list[1][0][0]
+        assert "my-channel::anaconda-env-manager" in install_args
 
     def test_uses_custom_package_name(self, monkeypatch, mocker: MockerFixture):
         monkeypatch.setenv("ANACONDA_AUTH_ENV_MANAGER_PACKAGE", "custom-pkg")
 
         from anaconda_auth._conda.env_logger_config import install_env_manager
 
-        mock_proc = mocker.MagicMock(returncode=0, stderr="")
+        mock_tos_proc = mocker.MagicMock(returncode=0)
+        mock_install_proc = mocker.MagicMock(returncode=0, stdout="{}", stderr="")
         mock_run = mocker.patch(
             "anaconda_auth._conda.env_logger_config.subprocess.run",
-            return_value=mock_proc,
+            side_effect=[mock_tos_proc, mock_install_proc],
         )
         install_env_manager(CONDA_PATH)
 
-        args = mock_run.call_args[0][0]
+        args = mock_run.call_args_list[1][0][0]
         assert "anaconda-cloud::custom-pkg" in args
 
 

--- a/tests/test_env_logger_config.py
+++ b/tests/test_env_logger_config.py
@@ -89,6 +89,7 @@ class TestInstallEnvManager:
         success, error = install_env_manager(CONDA_PATH)
         assert success is False
         assert "1" in error
+        assert "See output above for details." in error
 
     def test_pins_version_when_configured(self, monkeypatch, mocker: MockerFixture):
         monkeypatch.setenv("ANACONDA_AUTH_ENV_MANAGER_VERSION", "1.2.3")

--- a/tests/test_env_logger_config.py
+++ b/tests/test_env_logger_config.py
@@ -2,9 +2,32 @@ from __future__ import annotations
 
 import json
 
+import pytest
 from pytest_mock import MockerFixture
 
 CONDA_PATH = "/usr/bin/conda"
+
+
+@pytest.fixture
+def mock_install_flow(mocker: MockerFixture):
+    """Patch subprocess.run for install_env_manager's probe/tos/install calls.
+
+    Call with the install-step mock proc (and optionally the probe/tos
+    returncodes) to get back the patched mock_run, so the ordered
+    side_effect list lives in one place.
+    """
+
+    def _mock_install_flow(mock_install_proc, probe_returncode=0, tos_returncode=0):
+        side_effect = [mocker.MagicMock(returncode=probe_returncode)]
+        if probe_returncode == 0:
+            side_effect.append(mocker.MagicMock(returncode=tos_returncode))
+        side_effect.append(mock_install_proc)
+        return mocker.patch(
+            "anaconda_auth._conda.env_logger_config.subprocess.run",
+            side_effect=side_effect,
+        )
+
+    return _mock_install_flow
 
 
 class TestIsEnvManagerInstalled:
@@ -65,134 +88,195 @@ class TestIsEnvManagerInstalled:
         assert is_env_manager_installed(CONDA_PATH) is False
 
 
-class TestInstallEnvManager:
-    def test_returns_true_on_success(self, mocker: MockerFixture):
-        from anaconda_auth._conda.env_logger_config import install_env_manager
+class TestTosPluginAvailable:
+    def test_returns_true_when_available(self, mocker: MockerFixture):
+        from anaconda_auth._conda.env_logger_config import _tos_plugin_available
 
-        mock_tos_proc = mocker.MagicMock(returncode=0)
-        mock_install_proc = mocker.MagicMock(returncode=0, stdout="{}", stderr="")
+        mock_proc = mocker.MagicMock(returncode=0)
         mock_run = mocker.patch(
             "anaconda_auth._conda.env_logger_config.subprocess.run",
-            side_effect=[mock_tos_proc, mock_install_proc],
+            return_value=mock_proc,
         )
+        assert _tos_plugin_available(CONDA_PATH) is True
+
+        args = mock_run.call_args[0][0]
+        assert args == [CONDA_PATH, "tos", "--json", "info"]
+        # Must not inherit stdio.
+        assert mock_run.call_args.kwargs.get("capture_output") is True
+
+    def test_returns_false_when_not_available(self, mocker: MockerFixture):
+        from anaconda_auth._conda.env_logger_config import _tos_plugin_available
+
+        mock_proc = mocker.MagicMock(returncode=2)
+        mocker.patch(
+            "anaconda_auth._conda.env_logger_config.subprocess.run",
+            return_value=mock_proc,
+        )
+        assert _tos_plugin_available(CONDA_PATH) is False
+
+    def test_logs_debug_message_when_probe_fails(self, caplog, mocker: MockerFixture):
+        """Probe failures must be logged, not silently swallowed."""
+        import logging
+
+        from anaconda_auth._conda.env_logger_config import _tos_plugin_available
+
+        mock_proc = mocker.MagicMock(
+            returncode=2, stdout="", stderr="conda tos: error: invalid choice"
+        )
+        mocker.patch(
+            "anaconda_auth._conda.env_logger_config.subprocess.run",
+            return_value=mock_proc,
+        )
+        logger_name = "anaconda_auth._conda.env_logger_config"
+        with caplog.at_level(logging.DEBUG, logger=logger_name):
+            _tos_plugin_available(CONDA_PATH)
+
+        assert any(
+            "conda tos probe failed" in record.message for record in caplog.records
+        )
+        assert any("invalid choice" in record.message for record in caplog.records)
+
+
+class TestInstallEnvManager:
+    def test_returns_true_on_success(self, mocker: MockerFixture, mock_install_flow):
+        from anaconda_auth._conda.env_logger_config import install_env_manager
+
+        mock_install_proc = mocker.MagicMock(returncode=0, stdout="{}", stderr="")
+        mock_run = mock_install_flow(mock_install_proc)
         success, error = install_env_manager(CONDA_PATH)
         assert success is True
         assert error == ""
 
-        tos_args = mock_run.call_args_list[0][0][0]
+        tos_args = mock_run.call_args_list[1][0][0]
         assert "tos" in tos_args
         assert "interactive" in tos_args
-        # ToS step inherits stdio: no capture_output kwarg passed.
-        assert "capture_output" not in mock_run.call_args_list[0].kwargs
+        # Must inherit stdio.
+        assert "capture_output" not in mock_run.call_args_list[1].kwargs
 
-        install_args = mock_run.call_args_list[1][0][0]
+        install_args = mock_run.call_args_list[2][0][0]
         assert "--yes" in install_args
         assert "--json" in install_args
-        assert mock_run.call_args_list[1].kwargs.get("capture_output") is True
+        assert mock_run.call_args_list[2].kwargs.get("capture_output") is True
 
-    def test_returns_false_when_tos_rejected(self, mocker: MockerFixture):
+    def test_skips_interactive_step_when_plugin_not_available(
+        self, mocker: MockerFixture, mock_install_flow
+    ):
         from anaconda_auth._conda.env_logger_config import install_env_manager
 
-        mock_tos_proc = mocker.MagicMock(returncode=1)
-        mock_run = mocker.patch(
-            "anaconda_auth._conda.env_logger_config.subprocess.run",
-            return_value=mock_tos_proc,
-        )
-        success, error = install_env_manager(CONDA_PATH)
-        assert success is False
-        assert "Terms of Service" in error
-        # Install should never be attempted if ToS wasn't accepted.
-        mock_run.assert_called_once()
-
-    def test_proceeds_when_tos_plugin_not_installed(self, mocker: MockerFixture):
-        from anaconda_auth._conda.env_logger_config import install_env_manager
-
-        mock_tos_proc = mocker.MagicMock(returncode=2)
         mock_install_proc = mocker.MagicMock(returncode=0, stdout="{}", stderr="")
-        mocker.patch(
-            "anaconda_auth._conda.env_logger_config.subprocess.run",
-            side_effect=[mock_tos_proc, mock_install_proc],
-        )
+        mock_run = mock_install_flow(mock_install_proc, probe_returncode=2)
+        success, error = install_env_manager(CONDA_PATH)
+        assert success is True
+        assert error == ""
+        # No "tos interactive" call.
+        assert mock_run.call_count == 2
+
+    def test_proceeds_when_tos_interactive_fails(
+        self, mocker: MockerFixture, mock_install_flow
+    ):
+        """A ToS step failure must never block the install."""
+        from anaconda_auth._conda.env_logger_config import install_env_manager
+
+        mock_install_proc = mocker.MagicMock(returncode=0, stdout="{}", stderr="")
+        mock_install_flow(mock_install_proc, tos_returncode=1)
         success, error = install_env_manager(CONDA_PATH)
         assert success is True
         assert error == ""
 
-    def test_returns_false_on_failure(self, mocker: MockerFixture):
+    def test_returns_false_on_failure(self, mocker: MockerFixture, mock_install_flow):
         from anaconda_auth._conda.env_logger_config import install_env_manager
 
-        mock_tos_proc = mocker.MagicMock(returncode=0)
         mock_install_proc = mocker.MagicMock(returncode=1, stdout="{}", stderr="")
-        mocker.patch(
-            "anaconda_auth._conda.env_logger_config.subprocess.run",
-            side_effect=[mock_tos_proc, mock_install_proc],
-        )
+        mock_install_flow(mock_install_proc)
         success, error = install_env_manager(CONDA_PATH)
         assert success is False
-        assert "1" in error
+        assert error == "conda install exited with code 1."
 
-    def test_includes_json_error_message_on_failure(self, mocker: MockerFixture):
+    def test_includes_json_error_message_on_failure(
+        self, mocker: MockerFixture, mock_install_flow
+    ):
         from anaconda_auth._conda.env_logger_config import install_env_manager
 
-        mock_tos_proc = mocker.MagicMock(returncode=0)
         mock_install_proc = mocker.MagicMock(
             returncode=1,
             stdout='{"message": "PackagesNotFoundError: nope"}',
             stderr="",
         )
-        mocker.patch(
-            "anaconda_auth._conda.env_logger_config.subprocess.run",
-            side_effect=[mock_tos_proc, mock_install_proc],
-        )
+        mock_install_flow(mock_install_proc)
         success, error = install_env_manager(CONDA_PATH)
         assert success is False
         assert "PackagesNotFoundError: nope" in error
 
-    def test_pins_version_when_configured(self, monkeypatch, mocker: MockerFixture):
+    def test_falls_back_to_stderr_when_stdout_has_no_json_message(
+        self, mocker: MockerFixture, mock_install_flow
+    ):
+        """Falls back to stderr when stdout has no usable JSON message."""
+        from anaconda_auth._conda.env_logger_config import install_env_manager
+
+        mock_install_proc = mocker.MagicMock(
+            returncode=1,
+            stdout="",
+            stderr="CondaHTTPError: connection failed",
+        )
+        mock_install_flow(mock_install_proc)
+        success, error = install_env_manager(CONDA_PATH)
+        assert success is False
+        assert "CondaHTTPError: connection failed" in error
+
+    def test_handles_none_stdout_without_raising(
+        self, mocker: MockerFixture, mock_install_flow
+    ):
+        """json.loads(None) raises TypeError; must be caught, not raised."""
+        from anaconda_auth._conda.env_logger_config import install_env_manager
+
+        mock_install_proc = mocker.MagicMock(
+            returncode=1, stdout=None, stderr="unexpected crash"
+        )
+        mock_install_flow(mock_install_proc)
+        success, error = install_env_manager(CONDA_PATH)
+        assert success is False
+        assert "unexpected crash" in error
+
+    def test_pins_version_when_configured(
+        self, monkeypatch, mocker: MockerFixture, mock_install_flow
+    ):
         monkeypatch.setenv("ANACONDA_AUTH_ENV_MANAGER_VERSION", "1.2.3")
 
         from anaconda_auth._conda.env_logger_config import install_env_manager
 
-        mock_tos_proc = mocker.MagicMock(returncode=0)
         mock_install_proc = mocker.MagicMock(returncode=0, stdout="{}", stderr="")
-        mock_run = mocker.patch(
-            "anaconda_auth._conda.env_logger_config.subprocess.run",
-            side_effect=[mock_tos_proc, mock_install_proc],
-        )
+        mock_run = mock_install_flow(mock_install_proc)
         install_env_manager(CONDA_PATH)
 
-        args = mock_run.call_args_list[1][0][0]
+        args = mock_run.call_args_list[2][0][0]
         assert "anaconda-cloud::anaconda-env-manager=1.2.3" in args
 
-    def test_uses_custom_channel(self, monkeypatch, mocker: MockerFixture):
+    def test_uses_custom_channel(
+        self, monkeypatch, mocker: MockerFixture, mock_install_flow
+    ):
         monkeypatch.setenv("ANACONDA_AUTH_ENV_MANAGER_CHANNEL", "my-channel")
 
         from anaconda_auth._conda.env_logger_config import install_env_manager
 
-        mock_tos_proc = mocker.MagicMock(returncode=0)
         mock_install_proc = mocker.MagicMock(returncode=0, stdout="{}", stderr="")
-        mock_run = mocker.patch(
-            "anaconda_auth._conda.env_logger_config.subprocess.run",
-            side_effect=[mock_tos_proc, mock_install_proc],
-        )
+        mock_run = mock_install_flow(mock_install_proc)
         install_env_manager(CONDA_PATH)
 
-        install_args = mock_run.call_args_list[1][0][0]
+        install_args = mock_run.call_args_list[2][0][0]
         assert "my-channel::anaconda-env-manager" in install_args
 
-    def test_uses_custom_package_name(self, monkeypatch, mocker: MockerFixture):
+    def test_uses_custom_package_name(
+        self, monkeypatch, mocker: MockerFixture, mock_install_flow
+    ):
         monkeypatch.setenv("ANACONDA_AUTH_ENV_MANAGER_PACKAGE", "custom-pkg")
 
         from anaconda_auth._conda.env_logger_config import install_env_manager
 
-        mock_tos_proc = mocker.MagicMock(returncode=0)
         mock_install_proc = mocker.MagicMock(returncode=0, stdout="{}", stderr="")
-        mock_run = mocker.patch(
-            "anaconda_auth._conda.env_logger_config.subprocess.run",
-            side_effect=[mock_tos_proc, mock_install_proc],
-        )
+        mock_run = mock_install_flow(mock_install_proc)
         install_env_manager(CONDA_PATH)
 
-        args = mock_run.call_args_list[1][0][0]
+        args = mock_run.call_args_list[2][0][0]
         assert "anaconda-cloud::custom-pkg" in args
 
 

--- a/tests/test_env_logger_config.py
+++ b/tests/test_env_logger_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 
 import pytest
 from pytest_mock import MockerFixture
@@ -18,9 +19,18 @@ def mock_install_flow(mocker: MockerFixture):
     """
 
     def _mock_install_flow(mock_install_proc, probe_returncode=0, tos_returncode=0):
-        side_effect = [mocker.MagicMock(returncode=probe_returncode)]
+        probe_stdout = (
+            json.dumps([{"name": "conda-anaconda-tos"}])
+            if probe_returncode == 0
+            else ""
+        )
+        side_effect = [
+            mocker.MagicMock(
+                returncode=probe_returncode, stdout=probe_stdout, stderr=""
+            )
+        ]
         if probe_returncode == 0:
-            side_effect.append(mocker.MagicMock(returncode=tos_returncode))
+            side_effect.append(mocker.MagicMock(returncode=tos_returncode, stderr=""))
         side_effect.append(mock_install_proc)
         return mocker.patch(
             "anaconda_auth._conda.env_logger_config.subprocess.run",
@@ -92,7 +102,10 @@ class TestTosPluginAvailable:
     def test_returns_true_when_available(self, mocker: MockerFixture):
         from anaconda_auth._conda.env_logger_config import _tos_plugin_available
 
-        mock_proc = mocker.MagicMock(returncode=0)
+        packages = [{"name": "conda-anaconda-tos", "version": "0.2.2"}]
+        mock_proc = mocker.MagicMock(
+            returncode=0, stdout=json.dumps(packages), stderr=""
+        )
         mock_run = mocker.patch(
             "anaconda_auth._conda.env_logger_config.subprocess.run",
             return_value=mock_proc,
@@ -100,14 +113,41 @@ class TestTosPluginAvailable:
         assert _tos_plugin_available(CONDA_PATH) is True
 
         args = mock_run.call_args[0][0]
-        assert args == [CONDA_PATH, "tos", "--json", "info"]
-        # Must not inherit stdio.
+        assert args == [
+            CONDA_PATH,
+            "list",
+            "-n",
+            "base",
+            "conda-anaconda-tos",
+            "--json",
+        ]
+        # A local metadata read only, not a live network probe.
         assert mock_run.call_args.kwargs.get("capture_output") is True
 
-    def test_returns_false_when_not_available(self, mocker: MockerFixture):
+    def test_returns_false_when_not_installed(self, mocker: MockerFixture):
         from anaconda_auth._conda.env_logger_config import _tos_plugin_available
 
-        mock_proc = mocker.MagicMock(returncode=2)
+        mock_proc = mocker.MagicMock(returncode=0, stdout=json.dumps([]), stderr="")
+        mocker.patch(
+            "anaconda_auth._conda.env_logger_config.subprocess.run",
+            return_value=mock_proc,
+        )
+        assert _tos_plugin_available(CONDA_PATH) is False
+
+    def test_returns_false_on_command_failure(self, mocker: MockerFixture):
+        from anaconda_auth._conda.env_logger_config import _tos_plugin_available
+
+        mock_proc = mocker.MagicMock(returncode=1, stdout="", stderr="error")
+        mocker.patch(
+            "anaconda_auth._conda.env_logger_config.subprocess.run",
+            return_value=mock_proc,
+        )
+        assert _tos_plugin_available(CONDA_PATH) is False
+
+    def test_returns_false_on_invalid_json(self, mocker: MockerFixture):
+        from anaconda_auth._conda.env_logger_config import _tos_plugin_available
+
+        mock_proc = mocker.MagicMock(returncode=0, stdout="not json", stderr="")
         mocker.patch(
             "anaconda_auth._conda.env_logger_config.subprocess.run",
             return_value=mock_proc,
@@ -120,9 +160,7 @@ class TestTosPluginAvailable:
 
         from anaconda_auth._conda.env_logger_config import _tos_plugin_available
 
-        mock_proc = mocker.MagicMock(
-            returncode=2, stdout="", stderr="conda tos: error: invalid choice"
-        )
+        mock_proc = mocker.MagicMock(returncode=1, stdout="", stderr="CondaError")
         mocker.patch(
             "anaconda_auth._conda.env_logger_config.subprocess.run",
             return_value=mock_proc,
@@ -132,9 +170,10 @@ class TestTosPluginAvailable:
             _tos_plugin_available(CONDA_PATH)
 
         assert any(
-            "conda tos probe failed" in record.message for record in caplog.records
+            "conda-anaconda-tos probe failed" in record.message
+            for record in caplog.records
         )
-        assert any("invalid choice" in record.message for record in caplog.records)
+        assert any("CondaError" in record.message for record in caplog.records)
 
 
 class TestInstallEnvManager:
@@ -150,8 +189,9 @@ class TestInstallEnvManager:
         tos_args = mock_run.call_args_list[1][0][0]
         assert "tos" in tos_args
         assert "interactive" in tos_args
-        # Must inherit stdio.
+        # Prompts must inherit stdout; only stderr is captured (and logged).
         assert "capture_output" not in mock_run.call_args_list[1].kwargs
+        assert mock_run.call_args_list[1].kwargs.get("stderr") == subprocess.PIPE
 
         install_args = mock_run.call_args_list[2][0][0]
         assert "--yes" in install_args
@@ -181,7 +221,36 @@ class TestInstallEnvManager:
         mock_install_flow(mock_install_proc, tos_returncode=1)
         success, error = install_env_manager(CONDA_PATH)
         assert success is True
-        assert error == ""
+
+    def test_logs_instead_of_printing_when_tos_interactive_fails(
+        self, caplog, mocker: MockerFixture, mock_install_flow
+    ):
+        """ToS interactive stderr (e.g. rejection, transient errors) must be
+        logged, not printed, so it doesn't duplicate conda install's own
+        `--json` error message or look like a broken install."""
+        import logging
+
+        from anaconda_auth._conda.env_logger_config import install_env_manager
+
+        side_effect = [
+            mocker.MagicMock(
+                returncode=0, stdout=json.dumps([{"name": "conda-anaconda-tos"}])
+            ),
+            mocker.MagicMock(returncode=1, stderr="CondaToSRejectedError"),
+            mocker.MagicMock(returncode=0, stdout="{}", stderr=""),
+        ]
+        mocker.patch(
+            "anaconda_auth._conda.env_logger_config.subprocess.run",
+            side_effect=side_effect,
+        )
+        logger_name = "anaconda_auth._conda.env_logger_config"
+        with caplog.at_level(logging.DEBUG, logger=logger_name):
+            success, _ = install_env_manager(CONDA_PATH)
+
+        assert success is True
+        assert any(
+            "CondaToSRejectedError" in record.message for record in caplog.records
+        )
 
     def test_returns_false_on_failure(self, mocker: MockerFixture, mock_install_flow):
         from anaconda_auth._conda.env_logger_config import install_env_manager

--- a/tests/test_env_logger_config.py
+++ b/tests/test_env_logger_config.py
@@ -81,14 +81,33 @@ class TestInstallEnvManager:
     def test_returns_false_on_failure(self, mocker: MockerFixture):
         from anaconda_auth._conda.env_logger_config import install_env_manager
 
-        mock_proc = mocker.MagicMock(returncode=1, stderr="error", stdout="")
+        mock_proc = mocker.MagicMock(returncode=1)
         mocker.patch(
             "anaconda_auth._conda.env_logger_config.subprocess.run",
             return_value=mock_proc,
         )
         success, error = install_env_manager(CONDA_PATH)
         assert success is False
-        assert error == "error"
+        assert "1" in error
+
+    def test_does_not_capture_output_or_pass_yes(self, mocker: MockerFixture):
+        """The subprocess must inherit stdio (no capture_output) and must not
+        pass -y, so conda's install confirmation and the conda-anaconda-tos
+        plugin's Terms of Service prompt can interact with the user.
+        """
+        from anaconda_auth._conda.env_logger_config import install_env_manager
+
+        mock_proc = mocker.MagicMock(returncode=0)
+        mock_run = mocker.patch(
+            "anaconda_auth._conda.env_logger_config.subprocess.run",
+            return_value=mock_proc,
+        )
+        install_env_manager(CONDA_PATH)
+
+        args = mock_run.call_args[0][0]
+        kwargs = mock_run.call_args[1]
+        assert "-y" not in args
+        assert "capture_output" not in kwargs
 
     def test_pins_version_when_configured(self, monkeypatch, mocker: MockerFixture):
         monkeypatch.setenv("ANACONDA_AUTH_ENV_MANAGER_VERSION", "1.2.3")

--- a/tests/test_env_logger_config.py
+++ b/tests/test_env_logger_config.py
@@ -90,7 +90,6 @@ class TestInstallEnvManager:
         assert success is False
         assert "1" in error
 
-
     def test_pins_version_when_configured(self, monkeypatch, mocker: MockerFixture):
         monkeypatch.setenv("ANACONDA_AUTH_ENV_MANAGER_VERSION", "1.2.3")
 

--- a/tests/test_env_logger_config.py
+++ b/tests/test_env_logger_config.py
@@ -222,26 +222,26 @@ class TestInstallEnvManager:
         success, error = install_env_manager(CONDA_PATH)
         assert success is True
 
-    def test_logs_instead_of_printing_when_tos_interactive_fails(
+    def test_logs_instead_of_printing_transient_tos_interactive_failure(
         self, caplog, mocker: MockerFixture, mock_install_flow
     ):
-        """ToS interactive stderr (e.g. rejection, transient errors) must be
-        logged, not printed, so it doesn't duplicate conda install's own
-        `--json` error message or look like a broken install."""
+        """Transient ToS step stderr (e.g. a network blip) must be logged,
+        not printed, so it doesn't look like a broken install when the
+        subsequent conda install actually succeeds."""
         import logging
 
         from anaconda_auth._conda.env_logger_config import install_env_manager
 
-        side_effect = [
-            mocker.MagicMock(
-                returncode=0, stdout=json.dumps([{"name": "conda-anaconda-tos"}])
-            ),
-            mocker.MagicMock(returncode=1, stderr="CondaToSRejectedError"),
-            mocker.MagicMock(returncode=0, stdout="{}", stderr=""),
-        ]
+        mock_install_proc = mocker.MagicMock(returncode=0, stdout="{}", stderr="")
         mocker.patch(
             "anaconda_auth._conda.env_logger_config.subprocess.run",
-            side_effect=side_effect,
+            side_effect=[
+                mocker.MagicMock(
+                    returncode=0, stdout=json.dumps([{"name": "conda-anaconda-tos"}])
+                ),
+                mocker.MagicMock(returncode=1, stderr="CondaHTTPError: timed out"),
+                mock_install_proc,
+            ],
         )
         logger_name = "anaconda_auth._conda.env_logger_config"
         with caplog.at_level(logging.DEBUG, logger=logger_name):
@@ -249,8 +249,45 @@ class TestInstallEnvManager:
 
         assert success is True
         assert any(
-            "CondaToSRejectedError" in record.message for record in caplog.records
+            "CondaHTTPError: timed out" in record.message for record in caplog.records
         )
+
+    def test_fails_fast_on_confirmed_tos_rejection(
+        self, mocker: MockerFixture, mock_install_flow
+    ):
+        """A confirmed rejection from `conda tos interactive` must fail
+        immediately, without ever attempting (or announcing) the install—
+        `conda install` would only fail again for the same reason."""
+        from anaconda_auth._conda.env_logger_config import install_env_manager
+
+        rejection_text = (
+            "CondaToSRejectedError: Terms of Service has been rejected for the "
+            "following channels. Please remove or accept them before proceeding:\n"
+            "    - https://repo.anaconda.com/pkgs/main"
+        )
+        mock_run = mocker.patch(
+            "anaconda_auth._conda.env_logger_config.subprocess.run",
+            side_effect=[
+                mocker.MagicMock(
+                    returncode=0, stdout=json.dumps([{"name": "conda-anaconda-tos"}])
+                ),
+                mocker.MagicMock(returncode=1, stderr=rejection_text),
+            ],
+        )
+        printed = []
+        mocker.patch(
+            "anaconda_auth._conda.env_logger_config.console.print",
+            side_effect=lambda *a, **k: printed.append(a[0] if a else ""),
+        )
+
+        success, error = install_env_manager(CONDA_PATH)
+
+        assert success is False
+        assert "Terms of Service has been rejected" in error
+        assert "CondaToSRejectedError" not in error
+        # conda install must never be attempted, nor announced.
+        assert mock_run.call_count == 2
+        assert printed == ["Checking channel Terms of Service..."]
 
     def test_returns_false_on_failure(self, mocker: MockerFixture, mock_install_flow):
         from anaconda_auth._conda.env_logger_config import install_env_manager
@@ -291,6 +328,34 @@ class TestInstallEnvManager:
         success, error = install_env_manager(CONDA_PATH)
         assert success is False
         assert "CondaHTTPError: connection failed" in error
+
+    def test_extracts_json_error_message_from_stderr_on_tos_rejection(
+        self, mocker: MockerFixture, mock_install_flow
+    ):
+        """conda writes the --json error payload to stderr (not stdout) when
+        it's raised from a pre-command hook, e.g. a rejected ToS. The clean
+        message should still be extracted rather than falling back to the
+        raw JSON blob."""
+        from anaconda_auth._conda.env_logger_config import install_env_manager
+
+        mock_install_proc = mocker.MagicMock(
+            returncode=1,
+            stdout="",
+            stderr=json.dumps(
+                {
+                    "message": "Terms of Service has been rejected for the following channels: defaults",
+                    "exception_name": "CondaToSRejectedError",
+                }
+            ),
+        )
+        mock_install_flow(mock_install_proc)
+        success, error = install_env_manager(CONDA_PATH)
+        assert success is False
+        assert (
+            "Terms of Service has been rejected for the following channels: defaults"
+            in error
+        )
+        assert "exception_name" not in error
 
     def test_handles_none_stdout_without_raising(
         self, mocker: MockerFixture, mock_install_flow


### PR DESCRIPTION
[BIG-8642](https://anaconda.atlassian.net/browse/BIG-8642)

This PR adjusts the env-manager installation flow so conda install runs interactively (inherits stdio) to allow conda’s install prompts and the conda-anaconda-tos plugin Terms of Service prompt to be shown to and answered by the user.

Changes:

Updated install_env_manager() to run subprocess.run() without captured output and removed -y to preserve interactive prompting.
Updated the failing-install unit test to align with the new error message behavior (exit-code-based error).

Original flow

```
$ anaconda login
Anaconda Environment Manager is required by your organization. It is recommended to install. Proceed? [y/n] (y): y
Installing anaconda-env-manager...
Error: Failed to install anaconda-env-manager.
CondaToSNonInteractiveError: Terms of Service have not been accepted for the following channels:
    - https://repo.anaconda.com/pkgs/main
    - https://repo.anaconda.com/pkgs/r
```

Clean install with fix

```
Anaconda Environment Manager is required by your organization. It is recommended to install. Proceed? [y/n] (y): y
Installing anaconda-env-manager...
Do you accept the Terms of Service (ToS) for https://repo.anaconda.com/pkgs/main? [(a)ccept/(r)eject/(v)iew]: a
Do you accept the Terms of Service (ToS) for https://repo.anaconda.com/pkgs/r? [(a)ccept/(r)eject/(v)iew]: a
2 channel Terms of Service accepted
✔︎ anaconda-env-manager installed successfully.
 Select an organization for environment logging:
```

ToS already rejected from the beginning:
<img width="1864" height="590" alt="image (5)" src="https://github.com/user-attachments/assets/ec58afba-5573-43d2-9652-abf0a4111005" />

ToS already accepted from the beginning
<img width="1662" height="386" alt="image (4)" src="https://github.com/user-attachments/assets/43bb6d0e-e674-4b3c-adac-fc8326972534" />

ToS rejected interactively
<img width="1632" height="628" alt="image (3)" src="https://github.com/user-attachments/assets/7b7892df-69f1-431a-a8c1-c4e7bf6b01f1" />

ToS plugin not installed
<img width="909" height="80" alt="image" src="https://github.com/user-attachments/assets/d1c1c520-a9a0-4743-9939-eaefe8f42164" />

With Debug we can see the ToS plugin info
<img width="927" height="165" alt="image" src="https://github.com/user-attachments/assets/c9361c47-d988-4fba-a3f7-e8f178fee605" />


[BIG-8642]: https://anaconda.atlassian.net/browse/BIG-8642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ