### PR TITLE
fix: Preserve repo tokens across login

### DIFF
--- a/src/anaconda_auth/actions.py
+++ b/src/anaconda_auth/actions.py
@@ -218,7 +218,10 @@ def _do_login(config: AnacondaAuthSite, basic: bool) -> None:
         config=config,
     )
 
-    token_info = TokenInfo(api_key=api_key, domain=config.domain)
+    # `save()` rewrites the whole keyring entry, so update the existing one: a
+    # fresh TokenInfo would discard repo tokens from `anaconda token install`.
+    token_info = TokenInfo.load(domain=config.domain, create=True)
+    token_info.api_key = api_key
     token_info.save()
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -43,6 +43,26 @@ def test_login_to_api_key(mocker: MockerFixture) -> None:
     }
 
 
+def test_login_preserves_installed_repo_tokens(mocker: MockerFixture) -> None:
+    """Login must not wipe repo tokens installed by `anaconda token install`."""
+    mocker.patch("anaconda_auth.actions.get_api_key", return_value="new-api-key")
+    # Mock both branches; config.toml may set use_device_flow per site.
+    mocker.patch("anaconda_auth.actions._do_auth_flow")
+    mocker.patch("anaconda_auth.actions._do_device_flow")
+
+    config = AnacondaAuthConfig()
+
+    existing = TokenInfo(domain=config.domain, api_key="old-api-key")
+    existing.set_repo_token("my-org", "repo-token")
+    existing.save()
+
+    login(force=True)  # reported flow: already logged in, confirms a new login
+
+    token_info = TokenInfo.load(config.domain)
+    assert token_info.api_key == "new-api-key"
+    assert token_info.get_repo_token("my-org") == "repo-token"
+
+
 ssl_verify_options = [
     pytest.param(None, "0", False, id="configured-false"),
     pytest.param(None, "1", True, id="configured-true"),


### PR DESCRIPTION
## Why

A user reported that `anaconda login` authenticates fine but then fails at the post-login env-manager step:

```
✓ Login successful!
Anaconda Environment Manager is required by your organization. It is recommended to install. Proceed? [y/n] (y): y
Installing anaconda-env-manager...
Error: Failed to install anaconda-env-manager.
AnacondaAuthError: Token not found for defaults. Please install token with `anaconda token install`.
```

**Root cause:** `_do_login` constructed a brand-new `TokenInfo` and saved it. `save()` rewrites the *entire* keyring entry for the domain, so every login silently deleted the repo tokens installed by `anaconda token install`. `_post_login_setup` then shells out to `conda install`, which can no longer authenticate against a token-gated channel.

There was no working order of operations — install the token first and login wipes it; login first and the install has already failed.

Only users whose `defaults` requires a repo token (e.g. an org channel on `repo.anaconda.cloud`) are affected, which is why it did not reproduce for anyone on stock public channels.

## What changed

`_do_login` now loads the existing keyring entry and updates `api_key` in place. Clearing credentials stays `anaconda logout`'s job, which deletes the whole entry by design.

**Behavior change worth naming:** repo tokens now survive a login as a *different* user on a shared machine, where previously they were wiped as a side effect. `logout` remains the documented way to clear them.

## How to test

**Automated**

```
pytest tests/test_auth.py
```

`test_login_preserves_installed_repo_tokens` fails on `main` with `TokenNotFoundError: Could not find repo token for org my-org` and passes here.

**Manual** — needs an org with a repo token:

```
anaconda token install      # install your org token
anaconda token list         # note your org token is listed
anaconda login --force      # re-authenticate
anaconda token list         # before this PR: your org token is gone. after: still there
```

Then, on a machine without env-manager, run `anaconda login` and confirm the "Anaconda Environment Manager is required..." prompt now installs successfully instead of erroring with `Token not found for defaults`.

## Notes

An earlier revision of this PR also added `-c <channel>` to the `conda install` invocation in `install_env_manager`. That has been split out: dry-runs showed it prepends the channel, which under `channel_priority: strict` pulls dependencies (e.g. `anaconda-cli-base`) off the user's configured channels onto `anaconda-cloud` — undesirable for orgs running a curated mirror. It is also not needed for the reported bug.
